### PR TITLE
accept repo name and ref as input to semgrep action

### DIFF
--- a/github-actions/semgrep/action.yml
+++ b/github-actions/semgrep/action.yml
@@ -12,7 +12,8 @@ runs:
     - name: Checkout App Repo
       uses: actions/checkout@v2
       with:
-        ref: ${{ github.ref }}
+        ref: ${{ inputs.REF }}
+        repository: ${{ inputs.REPOSITORY }}
     - name: Copy .semgrepignore to workspace
       run: |
         if [ ! -f ${{ github.workspace}}/.semgrepignore ]; then


### PR DESCRIPTION
### Notes
- Updating the semgrep action to scan against the repository/ref provided as input
- This is the accompanying change for https://github.com/Splunk-SOAR-Apps/.github/pull/2