### PR TITLE
Update start-release action to always submit next to main PR

### DIFF
--- a/.github/workflows/test-start-release.yml
+++ b/.github/workflows/test-start-release.yml
@@ -1,0 +1,26 @@
+name: Test Start Release
+
+on: [push]
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r github-actions/start-release/requirements.txt
+          pip install -r github-actions/start-release/dev-requirements.txt
+      - name: Run Tests
+        working-directory: github-actions/start-release
+        run: pytest tests

--- a/github-actions/start-release/start_release.py
+++ b/github-actions/start-release/start_release.py
@@ -52,8 +52,6 @@ def build_release_notes(release_version, unreleased_notes, app_json):
     if unreleased_notes[0] != UNRELEASED_MD_HEADER:
         raise ValueError('Expected the first line of {} to be the header {}'
                          .format(UNRELEASED_MD, UNRELEASED_MD_HEADER))
-    elif len(unreleased_notes) == 1:
-        return None
 
     publish_date = datetime.date.today().strftime(RELEASE_NOTES_DATE_FORMAT)
     release_notes = [
@@ -68,6 +66,9 @@ def build_release_notes(release_version, unreleased_notes, app_json):
             raise ValueError('Detected incorrectly formatted release note: \'{}\''
                              .format(note))
         release_notes.append(match.group())
+
+    if len(release_notes) == 2:
+        return None
 
     return '\n'.join(release_notes)
 

--- a/github-actions/start-release/start_release.py
+++ b/github-actions/start-release/start_release.py
@@ -58,6 +58,7 @@ def build_release_notes(release_version, unreleased_notes, app_json):
         RELEASE_NOTES_TOP_HEADER.format(app_json['name'], app_json['publisher'], publish_date),
         RELEASE_NOTES_VERSION_HEADER.format(release_version, publish_date)
     ]
+    new_notes_added = False
     for note in unreleased_notes[1:]:
         if not note or not note.strip():
             continue
@@ -66,8 +67,9 @@ def build_release_notes(release_version, unreleased_notes, app_json):
             raise ValueError('Detected incorrectly formatted release note: \'{}\''
                              .format(note))
         release_notes.append(match.group())
+        new_notes_added = True
 
-    if len(release_notes) == 2:
+    if not new_notes_added:
         return None
 
     return '\n'.join(release_notes)

--- a/github-actions/start-release/tests/test_start_release.py
+++ b/github-actions/start-release/tests/test_start_release.py
@@ -17,9 +17,9 @@ logging.getLogger().setLevel(logging.INFO)
 APP_NAME = 'App'
 PUBLISHER = 'Splunk'
 DATE = datetime.date.today().strftime(RELEASE_NOTES_DATE_FORMAT)
-NEXT_VERSION_OKAY = '1.1'
-NEXT_VERSION_TOO_SMALL = '1.0'
-MAIN_VERSION = '1.0'
+NEXT_VERSION_OKAY = '1.0.1'
+NEXT_VERSION_TOO_SMALL = '1.0.0'
+MAIN_VERSION = '1.0.0'
 
 
 @pytest.fixture(name='session', scope='function')
@@ -64,21 +64,29 @@ def test_start_release_happy_path(session, next_version, main_version):
     session.get.side_effect = [[{'name': '{}.json'.format(APP_NAME)}], app_json_next, app_json_main,
                                mock_unreleased_md(), {'object': {'sha': base_sha}}]
 
-    session.post = MagicMock()
-    session.post.side_effect = itertools.chain([{'sha': s} for s in
-                                                (json_sha, release_note_sha, unreleased_sha, tree_sha, commit_sha)],
-                                               [{'html_url': 'url'}])
-
-    start_release(session)
-
     main_version = main_version or FIRST_VERSION
     if LooseVersion(next_version) <= LooseVersion(main_version):
         expected_next_version = main_version[:-1] + str(int(main_version[-1]) + 1)
         app_json, indent = deserialize_app_json(app_json_next)
         app_json['app_version'] = expected_next_version
+
+        app_json_next = app_json_next.copy()
         app_json_next['content'] = base64.b64encode(json.dumps(app_json, indent=indent).encode(DEFAULT_ENCODING))
+
+        post_blob_sha_l = [json_sha, release_note_sha, unreleased_sha, tree_sha, commit_sha]
+        expected_blobs = [base64.b64decode(app_json_next['content']).decode(DEFAULT_ENCODING)]
+        expected_tree = [('{}.json'.format(APP_NAME), json_sha)]
     else:
         expected_next_version = next_version
+        post_blob_sha_l = [release_note_sha, unreleased_sha, tree_sha, commit_sha]
+        expected_blobs = []
+        expected_tree = []
+
+    session.post = MagicMock()
+    post_l = [{'sha': s} for s in post_blob_sha_l] + [{'html_url': 'url'}]
+    session.post.side_effect = post_l
+
+    start_release(session)
 
     assert session.get.call_count == 5
     assert session.get.call_args_list[0] == call('contents?ref=next')
@@ -87,8 +95,7 @@ def test_start_release_happy_path(session, next_version, main_version):
     assert session.get.call_args_list[3] == call('contents/release_notes/unreleased.md?ref=next')
     assert session.get.call_args_list[4] == call('git/ref/heads/next')
 
-    assert session.post.call_count == 6
-    expected_blobs = [base64.b64decode(app_json_next['content']).decode(DEFAULT_ENCODING)]
+    assert session.post.call_count == len(post_l)
     with open('tests/data/expected_release_notes.md') as f:
         expected_blobs.append(f.read()\
                                .replace('<APP_NAME>', 'App')\
@@ -97,26 +104,27 @@ def test_start_release_happy_path(session, next_version, main_version):
                                .replace('<VERSION>', expected_next_version))
     expected_blobs.append('{}\n'.format(UNRELEASED_MD_HEADER))
 
+    expected_tree.append(('release_notes/{}.md'.format(expected_next_version), release_note_sha))
+    expected_tree.append(('release_notes/unreleased.md', unreleased_sha))
+
     for i, blob in enumerate(expected_blobs):
         assert session.post.call_args_list[i] == call('git/blobs', content=blob, encoding=DEFAULT_ENCODING)
 
     expected_tree = [{'mode': '100644', 'type': 'blob', 'path': path, 'sha': sha}
-                     for path, sha in (('{}.json'.format(APP_NAME), json_sha),
-                                       ('release_notes/{}.md'.format(expected_next_version), release_note_sha),
-                                       ('release_notes/unreleased.md', unreleased_sha))]
+                     for path, sha in expected_tree]
 
-    assert session.post.call_args_list[3] == call('git/trees', tree=expected_tree, base_tree=base_sha)
-    assert session.post.call_args_list[4] == call('git/commits',
-                                                  tree=tree_sha, parents=[base_sha],
-                                                  message=RELEASE_NOTE_COMMIT_MSG.format(expected_next_version),
-                                                  author=COMMIT_AUTHOR)
+    assert session.post.call_args_list[-3] == call('git/trees', tree=expected_tree, base_tree=base_sha)
+    assert session.post.call_args_list[-2] == call('git/commits',
+                                                   tree=tree_sha, parents=[base_sha],
+                                                   message=RELEASE_NOTE_COMMIT_MSG.format(expected_next_version),
+                                                   author=COMMIT_AUTHOR)
     assert session.patch.call_count == 1
     assert session.patch.call_args_list[0] == call('git/refs/heads/next', sha=commit_sha)
 
-    assert session.post.call_args_list[5] == call('pulls', head='next', base='main',
-                                                  body=load_main_pr_body(),
-                                                  title=MAIN_PR_TITLE.format(expected_next_version),
-                                                  maintainers_can_modify=True)
+    assert session.post.call_args_list[-1] == call('pulls', head='next', base='main',
+                                                   body=load_main_pr_body(),
+                                                   title=MAIN_PR_TITLE.format(expected_next_version),
+                                                   maintainers_can_modify=True)
 
 
 zero_json_files = []
@@ -155,5 +163,9 @@ def test_start_release_nothing_to_release(session):
                                {'content': empty_unreleased_md}]
 
     start_release(session)
-    assert session.post.call_count == 0
     assert session.patch.call_count == 0
+    assert session.post.call_count == 1
+    assert session.post.call_args_list[0] == call('pulls', head='next', base='main',
+                                                  body=load_main_pr_body(),
+                                                  title=MAIN_PR_TITLE.format('1.1'),
+                                                  maintainers_can_modify=True)


### PR DESCRIPTION
### Notes
- The start-release job currently exits early if there's no entries in `unreleased.md`
- Updating the job to still submit a PR merging next --> main
- Configuring CI workflow to run unit tests for this job

### Testing
- Updated unit tests
- https://github.com/splunk-soar-connectors/awslambda/runs/3818971407 