### PR TITLE
Store tox.ini config at top level

### DIFF
--- a/pre-commit/orghooks.yaml
+++ b/pre-commit/orghooks.yaml
@@ -14,9 +14,7 @@ repos:
     rev: 5.9.3
     hooks:
     -   id: isort
-        args: [--settings-path, .hook_configs/tox.ini]
 -   repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     -   id: flake8
-        args: [--append-config, .hook_configs/tox.ini]

--- a/pre-commit/run-org-hooks
+++ b/pre-commit/run-org-hooks
@@ -11,23 +11,22 @@ import sys
 from pathlib import Path
 
 
-REPO_HOOK_CONFIGS_DIRNAME = '.hook_configs'
-
 orghooks_dir = os.path.dirname(os.path.realpath(__file__))
+
+LINT_CONFIG_FILE = 'tox.ini'
 
 
 def copy_configs(dest_dir):
     """ Make a copy of configurations for hooks if one doesn't exist. """
     dev_tools_dir = Path(orghooks_dir).parents[0]
     lint_configs_dir = dev_tools_dir / 'lint-configs'
-    repo_hook_configs_dir = Path(dest_dir) / REPO_HOOK_CONFIGS_DIRNAME
-    shutil.copytree(lint_configs_dir, repo_hook_configs_dir, dirs_exist_ok=True)
+    shutil.copyfile(lint_configs_dir / LINT_CONFIG_FILE, dest_dir / LINT_CONFIG_FILE)
 
 
 def main():
     """ Main entrypoint. """
     repo_dir = os.getcwd()
-    copy_configs(repo_dir)
+    copy_configs(Path(repo_dir))
     cfg = os.path.join(orghooks_dir, 'orghooks.yaml')
     cmd = ['pre-commit', 'run', '--config', cfg, '--files'] + sys.argv[1:]
     os.execvp(cmd[0], cmd)


### PR DESCRIPTION
By placing tox.ini at the top level, editors and IDEs can automatically detect and use the configuration. It should also be fine to commit it into the app repo since running a pre-commit update followed by pre-commit will update the config file automatically, so contributors can simply commit the updated file as well. There will be a separate PR removing the gitignore and excludes file added to the awslambda repo once there is a tag for these changes created in this repo..

Tested by running pre-commit locally against the awslambda repo.