### PR TITLE
Update start-release action to update release_notes.html

### DIFF
--- a/github-actions/start-release/tests/data/expected_new_release_notes.html
+++ b/github-actions/start-release/tests/data/expected_new_release_notes.html
@@ -1,0 +1,13 @@
+<b>APP_NAME Release Notes - Published by PUBLISHER PUBLISH_DATE</b>
+<br><br>
+<b>Version VERSION - Released PUBLISH_DATE</b>
+<ul>
+<li>foo</li>
+<li>bar</li>
+<li>baz</li>
+</ul>
+<b>Version 1.0.0 - Released January 01, 2020</b>
+<ul>
+<li>previous release note a</li>
+<li>previous release note b</li>
+</ul>

--- a/github-actions/start-release/tests/data/old_release_notes.html
+++ b/github-actions/start-release/tests/data/old_release_notes.html
@@ -1,0 +1,7 @@
+<b>APP_NAME Release Notes - Published by PUBLISHER PUBLISH_DATE</b>
+<br><br>
+<b>Version 1.0.0 - Released January 01, 2020</b>
+<ul>
+<li>previous release note a</li>
+<li>previous release note b</li>
+</ul>


### PR DESCRIPTION
### Notes
- Updating the start-release notes action to convert release notes from `unreleased.md` to HTML and prepend them to `release_notes.html`
- The purpose of this change is to allow us to write release notes in markdown and have them automatically converted and prepended to the HTML release notes

### Testing
- Ran the script locally to get https://github.com/splunk-soar-connectors/awscloudtrail/commit/602631086fcd8112681a65104561fe1ded7a594d and https://github.com/splunk-soar-connectors/awscloudtrail/pull/1
- Updated unit tests 