### PR TITLE
Update start_release action to skip postman_collection files

### DIFF
--- a/github-actions/start-release/api/github.py
+++ b/github-actions/start-release/api/github.py
@@ -1,6 +1,5 @@
 from http import HTTPStatus
 
-from requests import HTTPError
 from requests.adapters import Retry, HTTPAdapter
 from requests_toolbelt import sessions
 

--- a/github-actions/start-release/start_release.py
+++ b/github-actions/start-release/start_release.py
@@ -135,9 +135,11 @@ def load_main_pr_body():
 
 def start_release(session):
     # Fetch repo contents and find the app json file - which we
-    # expect to be the only json file
+    # expect to be the only json file other than a potential postman collection
     repo_files = session.get('contents?ref=next')
-    json_files = [f['name'] for f in repo_files if f['name'].lower().endswith('.json')]
+    json_files = [f['name'] for f in repo_files if
+                  not f['name'].lower().endswith('.postman_collection.json')
+                  and f['name'].lower().endswith('.json')]
 
     if len(json_files) != 1:
         raise ValueError('Expected a single json file in the repo but got {}'.format(json_files))

--- a/github-actions/start-release/tests/test_start_release.py
+++ b/github-actions/start-release/tests/test_start_release.py
@@ -69,7 +69,8 @@ def test_start_release_happy_path(session, next_version, main_version):
 
     app_json_next = mock_app_json(next_version)
     app_json_main = mock_app_json(main_version) if main_version else HTTPError(response=Mock(status=404))
-    session.get.side_effect = [[{'name': '{}.json'.format(APP_NAME)}], app_json_next, app_json_main,
+    session.get.side_effect = [[{'name': '{}.json'.format(APP_NAME)}, {'name': '{}.postman_collection.json'.format(APP_NAME)}],
+                               app_json_next, app_json_main,
                                mock_unreleased_md(), mock_release_notes_html(), {'object': {'sha': base_sha}}]
 
     main_version = main_version or FIRST_VERSION


### PR DESCRIPTION
### Notes
- Updating the start_release action to skip postman_collection files when searching for the app json

### Tests
- Updated unit tests

