### PR TITLE
Handle case where there is no existing HTML README

### DIFF
--- a/github-actions/start-release/tests/data/expected_new_release_notes_no_history.html
+++ b/github-actions/start-release/tests/data/expected_new_release_notes_no_history.html
@@ -1,0 +1,8 @@
+<b>APP_NAME Release Notes - Published by PUBLISHER PUBLISH_DATE</b>
+<br><br>
+<b>Version VERSION - Released PUBLISH_DATE</b>
+<ul>
+<li>foo</li>
+<li>bar</li>
+<li>baz</li>
+</ul>

--- a/pre-commit/tests/data/py3-app/expected_app_json.out
+++ b/pre-commit/tests/data/py3-app/expected_app_json.out
@@ -24,7 +24,7 @@
             },
             {
                 "module": "soupsieve",
-                "input_file": "wheels/soupsieve-2.3-py3-none-any.whl"
+                "input_file": "wheels/soupsieve-2.3.1-py3-none-any.whl"
             },
             {
                 "module": "urllib3",


### PR DESCRIPTION
Handle the case where there is no existing HTML readme file when generating the HTML readme during the start release action.

Parametrize the existing happy path unit test to also check the case when the HTML readme file returns a 404.