### PR TITLE
Disable semgrep-app integration

### DIFF
--- a/github-actions/semgrep/action.yml
+++ b/github-actions/semgrep/action.yml
@@ -23,6 +23,7 @@ runs:
     - name: 'Semgrep scan'
       uses: returntocorp/semgrep-action@v1   
       with:
+        config: p/python
         # Fetches configured rules from Semgrep account
-        publishDeployment: ${{ inputs.SEMGREP_DEPLOYMENT_ID }}
-        publishToken: ${{ inputs.SEMGREP_APP_TOKEN }}
+        # publishDeployment: ${{ inputs.SEMGREP_DEPLOYMENT_ID }}
+        # publishToken: ${{ inputs.SEMGREP_APP_TOKEN }}


### PR DESCRIPTION
### Notes
- Disabling semgrep-app integration until we can get its usage approved
- Scans will now use the default python ruleset https://semgrep.dev/p/python

### Testing
- https://github.com/splunk-soar-connectors/testrepo/runs/4258115669?check_suite_focus=true