### PR TITLE
Updating max line length for linting

### DIFF
--- a/lint-configs/tox.ini
+++ b/lint-configs/tox.ini
@@ -1,7 +1,7 @@
 [flake8]
-max-line-length = 130
+max-line-length = 145
 max-complexity = 28
 ignore = F403,E128,E126,E111,E121,E127,E731,E201,E202,F405,E722,D,W292
 
 [isort]
-line_length = 130
+line_length = 145


### PR DESCRIPTION
### Notes
- Updating the max line length used for linting from 130 chars to 145 chars
- This is to suppress most of the lint errors from calls to ` return action_result.set_status(...)` ([example](https://github.com/splunk-soar-connectors/carbonblackresponse/runs/4161155018?check_suite_focus=true)) while still reporting egregiously long lines