### PR TITLE
Dependabot: 1 jinja2 vulnerability found

### DIFF
--- a/github-actions/start-release/requirements.txt
+++ b/github-actions/start-release/requirements.txt
@@ -1,4 +1,4 @@
-Jinja2==2.11.2
+Jinja2==2.11.3
 Pygments==2.7.4
 beautifulsoup4==4.9.3
 gh-md-to-html==1.21.1


### PR DESCRIPTION
Dependabot: 1 jinja2 vulnerability found - Upgrade jinja2 to version …2.11.3 or later

See: https://github.com/phantomcyber/dev-cicd-tools/security/dependabot/github-actions/start-release/requirements.txt/jinja2/open