### PR TITLE
Wrap connecter_path in Path object

### DIFF
--- a/github-actions/start-release/build_docs.py
+++ b/github-actions/start-release/build_docs.py
@@ -192,8 +192,8 @@ def main(args):
     """
     Main entrypoint.
     """
-    connector_path = args.connector_path
-    from_html = args.from_html  == "True"
+    connector_path = Path(args.connector_path)
+    from_html = args.from_html == "True"
     if from_html:
         build_docs_from_html(connector_path)
     else:


### PR DESCRIPTION
### Notes
- Wrapping the `connector_path` input to `build_docs.py` in a `Path` object as later code branches reference to `Path` specific attributes