### PR TITLE
Updating commit author to splunk-soar-connectors-admin

### DIFF
--- a/github-actions/start-release/start_release.py
+++ b/github-actions/start-release/start_release.py
@@ -37,8 +37,8 @@ RELEASE_NOTE_COMMIT_MSG = 'Release notes for version {}'
 MAIN_PR_TITLE = 'Merging next to main for release {}'
 MAIN_PR_BODY_FILE = 'templates/main_pr_body.md'
 COMMIT_AUTHOR = {
-    'name': 'root',
-    'email': 'root@splunksoar'
+    'name': 'splunk-soar-connectors-admin',
+    'email': 'admin@splunksoar'
 }
 
 FIRST_VERSION = '1.0.0'


### PR DESCRIPTION
### Notes
- Updating the commit author used by start-release to be `splunk-soar-connectors-admin`