### PR TITLE
Preserve hard linebreaks for markdown files in pre-commit hook

### DIFF
--- a/pre-commit/orghooks.yaml
+++ b/pre-commit/orghooks.yaml
@@ -7,6 +7,7 @@ repos:
     -   id: check-merge-conflict
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
     -   id: requirements-txt-fixer
     -   id: check-json
     -   id: check-yaml


### PR DESCRIPTION
- Background: Currently, pre-commit trailing whitespace hook
trims all whitespace from the ends of lines, which may change how the page
is formatted from Markdown file. For example, hard linebreaks -
preceded by two or more spaces will not be preserved

- Fix: add an arg called [--markdown-linebreak-ext=md] to preserve
hard line break