### PR TITLE
Prevent markdown files from being modified when some pre-commit hooks are run

### DIFF
--- a/pre-commit/orghooks.yaml
+++ b/pre-commit/orghooks.yaml
@@ -7,7 +7,7 @@ repos:
     -   id: check-merge-conflict
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
-        exclude_types: ['md']
+        exclude_types: [markdown] 
     -   id: requirements-txt-fixer
     -   id: check-json
     -   id: check-yaml

--- a/pre-commit/orghooks.yaml
+++ b/pre-commit/orghooks.yaml
@@ -7,7 +7,7 @@ repos:
     -   id: check-merge-conflict
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
-        exclude_types: [md]
+        exclude_types: ['md']
     -   id: requirements-txt-fixer
     -   id: check-json
     -   id: check-yaml

--- a/pre-commit/orghooks.yaml
+++ b/pre-commit/orghooks.yaml
@@ -7,7 +7,7 @@ repos:
     -   id: check-merge-conflict
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
-        args: [--markdown-linebreak-ext=md]
+        exclude_types: [md]
     -   id: requirements-txt-fixer
     -   id: check-json
     -   id: check-yaml

--- a/pre-commit/orghooks.yaml
+++ b/pre-commit/orghooks.yaml
@@ -6,8 +6,9 @@ repos:
     hooks:
     -   id: check-merge-conflict
     -   id: end-of-file-fixer
+        exclude_types: [markdown]
     -   id: trailing-whitespace
-        exclude_types: [markdown] 
+        exclude_types: [markdown]
     -   id: requirements-txt-fixer
     -   id: check-json
     -   id: check-yaml


### PR DESCRIPTION
Some markdown files are getting modified as part of pre-commit hook execution. We should prevent this from happening, since the changes (even whitespace only) can modify how the documents are formatted.

### Testing

#### Before
<details>
  <summary>README.md is modified</summary>

```
jdemelo@C02D2551MD6R> splunk-soar-connectors (, play1.dev.us-wes) $  git clone git@github.com:splunk-soar-connectors/autofocus.git
Cloning into 'autofocus'...
remote: Enumerating objects: 182, done.
remote: Counting objects: 100% (182/182), done.
remote: Compressing objects: 100% (126/126), done.
remote: Total 182 (delta 76), reused 141 (delta 52), pack-reused 0
Receiving objects: 100% (182/182), 825.33 KiB | 1.13 MiB/s, done.
Resolving deltas: 100% (76/76), done.
jdemelo@C02D2551MD6R> splunk-soar-connectors (, play1.dev.us-wes) $ cd autofocus
jdemelo@C02D2551MD6R> autofocus (next, play1.dev.us-wes) $ pre-commit run --all-files
[INFO] Initializing environment for https://github.com/phantomcyber/dev-cicd-tools.
[INFO] Initializing environment for https://github.com/Yelp/detect-secrets.
[INFO] Installing environment for https://github.com/Yelp/detect-secrets.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
org-wide hooks...........................................................Failed
...
jdemelo@C02D2551MD6R> autofocus (next, play1.dev.us-wes) $ git status
On branch next
Your branch is up to date with 'origin/next'.

Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   .github/workflows/linting.yml
	modified:   .github/workflows/semgrep.yml
	modified:   .github/workflows/start-release.yml
	modified:   README.md
	modified:   af_get_report.html
	modified:   autofocus.json
	modified:   logo_paloaltonetworks.svg
	modified:   logo_paloaltonetworks_dark.svg
	deleted:    wheels/urllib3-1.26.7-py2.py3-none-any.whl

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	tox.ini
	wheels/urllib3-1.26.8-py2.py3-none-any.whl

no changes added to commit (use "git add" and/or "git commit -a")
jdemelo@C02D2551MD6R> autofocus (next, play1.dev.us-wes) $ 
```

</details>

#### After
<details>
  <summary>README.md is not modified</summary>

```
jdemelo@C02D2551MD6R> splunk-soar-connectors (, play1.dev.us-wes) $  git clone git@github.com:splunk-soar-connectors/autofocus.git
Cloning into 'autofocus'...
remote: Enumerating objects: 182, done.
remote: Counting objects: 100% (182/182), done.
remote: Compressing objects: 100% (126/126), done.
remote: Total 182 (delta 76), reused 141 (delta 52), pack-reused 0
Receiving objects: 100% (182/182), 825.33 KiB | 1.38 MiB/s, done.
Resolving deltas: 100% (76/76), done.
jdemelo@C02D2551MD6R> splunk-soar-connectors (, play1.dev.us-wes) $ cd autofocus
jdemelo@C02D2551MD6R> autofocus (next, play1.dev.us-wes) $ pre-commit try-repo https://github.com/phantomcyber/dev-cicd-tools --ref 64b2a413b862ccd2bad1373c2055237268d9f29c --all-files
[INFO] Initializing environment for https://github.com/phantomcyber/dev-cicd-tools.
===============================================================================
Using config:
===============================================================================
repos:
-   repo: https://github.com/phantomcyber/dev-cicd-tools
    rev: 64b2a413b862ccd2bad1373c2055237268d9f29c
    hooks:
    -   id: org-hook
    -   id: package-app-dependencies
...

jdemelo@C02D2551MD6R> autofocus (next, play1.dev.us-wes) $ git status
On branch next
Your branch is up to date with 'origin/next'.

Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   .github/workflows/linting.yml
	modified:   .github/workflows/semgrep.yml
	modified:   .github/workflows/start-release.yml
	modified:   af_get_report.html
	modified:   autofocus.json
	modified:   logo_paloaltonetworks.svg
	modified:   logo_paloaltonetworks_dark.svg
	deleted:    wheels/urllib3-1.26.7-py2.py3-none-any.whl

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	tox.ini
	wheels/urllib3-1.26.8-py2.py3-none-any.whl

no changes added to commit (use "git add" and/or "git commit -a")
jdemelo@C02D2551MD6R> autofocus (next, play1.dev.us-wes) $ 

```

</details>