### PR TITLE
Generate python 3.9 wheel files

### DIFF
--- a/pre-commit/package_app_dependencies
+++ b/pre-commit/package_app_dependencies
@@ -12,6 +12,14 @@ function package_py2_app_dependencies() {
   python "$SCRIPT_DIR/package_app_dependencies.py" "$APP_DIR" pip2 pip_dependencies
 }
 
+function package_py3_app_dependencies() {
+  PYTHON_VERSION_STRING=$1
+  PIP_DEPENDENCIES_KEY=$2
+  docker run --rm -v "$APP_DIR":/src -v "$SCRIPT_DIR":/pre-commit/ -w "$SCRIPT_DIR" \
+    quay.io/pypa/manylinux2014_x86_64 /bin/bash -c \
+     "/opt/python/cp39-cp39/bin/python /pre-commit/package_app_dependencies.py \
+     /src /opt/python/$PYTHON_VERSION_STRING/bin/pip $PIP_DEPENDENCIES_KEY --repair_wheels"
+}
 
 if ! jq --help &> /dev/null; then
   echo 'Please ensure jq is installed (eg, brew install jq)'
@@ -44,7 +52,7 @@ else
   fi
 fi
 
-docker run --rm -v "$APP_DIR":/src -v "$SCRIPT_DIR":/pre-commit/ -w "$SCRIPT_DIR" \
-  quay.io/pypa/manylinux2014_x86_64 /bin/bash -c \
-   "/opt/python/cp39-cp39/bin/python /pre-commit/package_app_dependencies.py \
-   /src /opt/python/cp36-cp36m/bin/pip $pip3_dependencies_key --repair_wheels"
+pip39_dependencies_key='pip39_dependencies'
+
+package_py3_app_dependencies 'cp36-cp36m' $pip3_dependencies_key
+package_py3_app_dependencies 'cp39-cp39' $pip39_dependencies_key

--- a/pre-commit/tests/data/app-with-pip2-pip3-deps/expected_app_json.out
+++ b/pre-commit/tests/data/app-with-pip2-pip3-deps/expected_app_json.out
@@ -1,59 +1,87 @@
 {
-    "python_version": "3",
-    "pip_dependencies": {
-        "wheel": [
-            {
-                "module": "certifi",
-                "input_file": "wheels/shared/certifi-2021.10.8-py2.py3-none-any.whl"
-            },
-            {
-                "module": "chardet",
-                "input_file": "wheels/shared/chardet-4.0.0-py2.py3-none-any.whl"
-            },
-            {
-                "module": "idna",
-                "input_file": "wheels/shared/idna-2.10-py2.py3-none-any.whl"
-            },
-            {
-                "module": "requests",
-                "input_file": "wheels/shared/requests-2.26.0-py2.py3-none-any.whl"
-            },
-            {
-                "module": "simplejson",
-                "input_file": "wheels/py2/existing-platform-wheel.whl"
-            },
-            {
-                "module": "urllib3",
-                "input_file": "wheels/shared/urllib3-1.26.8-py2.py3-none-any.whl"
-            }
-        ]
-    },
-    "pip3_dependencies": {
-        "wheel": [
-            {
-                "module": "certifi",
-                "input_file": "wheels/shared/certifi-2021.10.8-py2.py3-none-any.whl"
-            },
-            {
-                "module": "charset_normalizer",
-                "input_file": "wheels/py3/charset_normalizer-2.0.10-py3-none-any.whl"
-            },
-            {
-                "module": "idna",
-                "input_file": "wheels/py3/idna-3.3-py3-none-any.whl"
-            },
-            {
-                "module": "requests",
-                "input_file": "wheels/shared/requests-2.26.0-py2.py3-none-any.whl"
-            },
-            {
-                "module": "simplejson",
-                "input_file": "wheels/py3/simplejson-3.17.5-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-            },
-            {
-                "module": "urllib3",
-                "input_file": "wheels/shared/urllib3-1.26.8-py2.py3-none-any.whl"
-            }
-        ]
-    }
+  "python_version": "3",
+  "pip_dependencies": {
+    "wheel": [
+      {
+        "module": "certifi",
+        "input_file": "wheels/shared/certifi-2021.10.8-py2.py3-none-any.whl"
+      },
+      {
+        "module": "chardet",
+        "input_file": "wheels/shared/chardet-4.0.0-py2.py3-none-any.whl"
+      },
+      {
+        "module": "idna",
+        "input_file": "wheels/shared/idna-2.10-py2.py3-none-any.whl"
+      },
+      {
+        "module": "requests",
+        "input_file": "wheels/shared/requests-2.26.0-py2.py3-none-any.whl"
+      },
+      {
+        "module": "simplejson",
+        "input_file": "wheels/py2/existing-platform-wheel.whl"
+      },
+      {
+        "module": "urllib3",
+        "input_file": "wheels/shared/urllib3-1.26.8-py2.py3-none-any.whl"
+      }
+    ]
+  },
+  "pip3_dependencies": {
+    "wheel": [
+      {
+        "module": "certifi",
+        "input_file": "wheels/shared/certifi-2021.10.8-py2.py3-none-any.whl"
+      },
+      {
+        "module": "charset_normalizer",
+        "input_file": "wheels/py3/charset_normalizer-2.0.11-py3-none-any.whl"
+      },
+      {
+        "module": "idna",
+        "input_file": "wheels/py3/idna-3.3-py3-none-any.whl"
+      },
+      {
+        "module": "requests",
+        "input_file": "wheels/shared/requests-2.26.0-py2.py3-none-any.whl"
+      },
+      {
+        "module": "simplejson",
+        "input_file": "wheels/py36/simplejson-3.17.5-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+      },
+      {
+        "module": "urllib3",
+        "input_file": "wheels/shared/urllib3-1.26.8-py2.py3-none-any.whl"
+      }
+    ]
+  },
+  "pip39_dependencies": {
+    "wheel": [
+      {
+        "module": "certifi",
+        "input_file": "wheels/shared/certifi-2021.10.8-py2.py3-none-any.whl"
+      },
+      {
+        "module": "charset_normalizer",
+        "input_file": "wheels/py3/charset_normalizer-2.0.11-py3-none-any.whl"
+      },
+      {
+        "module": "idna",
+        "input_file": "wheels/py3/idna-3.3-py3-none-any.whl"
+      },
+      {
+        "module": "requests",
+        "input_file": "wheels/shared/requests-2.26.0-py2.py3-none-any.whl"
+      },
+      {
+        "module": "simplejson",
+        "input_file": "wheels/py39/simplejson-3.17.5-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+      },
+      {
+        "module": "urllib3",
+        "input_file": "wheels/shared/urllib3-1.26.8-py2.py3-none-any.whl"
+      }
+    ]
+  }
 }

--- a/pre-commit/tests/data/pure-python-py3-app/app.json
+++ b/pre-commit/tests/data/pure-python-py3-app/app.json
@@ -1,0 +1,35 @@
+{
+    "python_version": "3",
+    "pip_dependencies": {
+        "wheel": [
+            {
+                "module": "beautifulsoup4",
+                "input_file": "wheels/beautifulsoup4-4.9.1-py3-none-any.whl"
+            },
+            {
+                "module": "certifi",
+                "input_file": "wheels/certifi-2021.10.8-py2.py3-none-any.whl"
+            },
+            {
+                "module": "charset_normalizer",
+                "input_file": "wheels/charset_normalizer-2.0.7-py3-none-any.whl"
+            },
+            {
+                "module": "idna",
+                "input_file": "wheels/idna-3.3-py3-none-any.whl"
+            },
+            {
+                "module": "requests",
+                "input_file": "wheels/requests-2.26.0-py2.py3-none-any.whl"
+            },
+            {
+                "module": "soupsieve",
+                "input_file": "wheels/soupsieve-2.3-py3-none-any.whl"
+            },
+            {
+                "module": "urllib3",
+                "input_file": "wheels/urllib3-1.26.7-py2.py3-none-any.whl"
+            }
+        ]
+    }
+}

--- a/pre-commit/tests/data/pure-python-py3-app/expected_app_json.out
+++ b/pre-commit/tests/data/pure-python-py3-app/expected_app_json.out
@@ -1,0 +1,19 @@
+{
+  "python_version": "3",
+  "pip_dependencies": {
+    "wheel": [
+      {
+        "module": "beautifulsoup4",
+        "input_file": "wheels/py3/beautifulsoup4-4.9.1-py3-none-any.whl"
+      },
+      {
+        "module": "dnspython",
+        "input_file": "wheels/shared/dnspython-1.16.0-py2.py3-none-any.whl"
+      },
+      {
+        "module": "soupsieve",
+        "input_file": "wheels/py3/soupsieve-2.3.1-py3-none-any.whl"
+      }
+    ]
+  }
+}

--- a/pre-commit/tests/data/pure-python-py3-app/requirements.txt
+++ b/pre-commit/tests/data/pure-python-py3-app/requirements.txt
@@ -1,0 +1,2 @@
+beautifulsoup4==4.9.1
+dnspython==1.16.0

--- a/pre-commit/tests/data/py2-app/expected_app_json.out
+++ b/pre-commit/tests/data/py2-app/expected_app_json.out
@@ -1,39 +1,39 @@
 {
-    "python_version": "2.7",
-    "pip_dependencies": {
-        "wheel": [
-            {
-                "module": "backports.functools_lru_cache",
-                "input_file": "wheels/backports.functools_lru_cache-1.6.4-py2.py3-none-any.whl"
-            },
-            {
-                "module": "beautifulsoup4",
-                "input_file": "wheels/beautifulsoup4-4.9.1-py2-none-any.whl"
-            },
-            {
-                "module": "certifi",
-                "input_file": "wheels/certifi-2021.10.8-py2.py3-none-any.whl"
-            },
-            {
-                "module": "chardet",
-                "input_file": "wheels/chardet-4.0.0-py2.py3-none-any.whl"
-            },
-            {
-                "module": "idna",
-                "input_file": "wheels/idna-2.10-py2.py3-none-any.whl"
-            },
-            {
-                "module": "requests",
-                "input_file": "wheels/requests-2.26.0-py2.py3-none-any.whl"
-            },
-            {
-                "module": "soupsieve",
-                "input_file": "wheels/soupsieve-1.9.6-py2.py3-none-any.whl"
-            },
-            {
-                "module": "urllib3",
-                "input_file": "wheels/urllib3-1.26.8-py2.py3-none-any.whl"
-            }
-        ]
-    }
+  "python_version": "2.7",
+  "pip_dependencies": {
+    "wheel": [
+      {
+        "module": "backports.functools_lru_cache",
+        "input_file": "wheels/shared/backports.functools_lru_cache-1.6.4-py2.py3-none-any.whl"
+      },
+      {
+        "module": "beautifulsoup4",
+        "input_file": "wheels/py2/beautifulsoup4-4.9.1-py2-none-any.whl"
+      },
+      {
+        "module": "certifi",
+        "input_file": "wheels/shared/certifi-2021.10.8-py2.py3-none-any.whl"
+      },
+      {
+        "module": "chardet",
+        "input_file": "wheels/shared/chardet-4.0.0-py2.py3-none-any.whl"
+      },
+      {
+        "module": "idna",
+        "input_file": "wheels/shared/idna-2.10-py2.py3-none-any.whl"
+      },
+      {
+        "module": "requests",
+        "input_file": "wheels/shared/requests-2.26.0-py2.py3-none-any.whl"
+      },
+      {
+        "module": "soupsieve",
+        "input_file": "wheels/shared/soupsieve-1.9.6-py2.py3-none-any.whl"
+      },
+      {
+        "module": "urllib3",
+        "input_file": "wheels/shared/urllib3-1.26.8-py2.py3-none-any.whl"
+      }
+    ]
+  }
 }

--- a/pre-commit/tests/data/py3-app/expected_app_json.out
+++ b/pre-commit/tests/data/py3-app/expected_app_json.out
@@ -1,35 +1,75 @@
 {
-    "python_version": "3",
-    "pip_dependencies": {
-        "wheel": [
-            {
-                "module": "beautifulsoup4",
-                "input_file": "wheels/beautifulsoup4-4.9.1-py3-none-any.whl"
-            },
-            {
-                "module": "certifi",
-                "input_file": "wheels/certifi-2021.10.8-py2.py3-none-any.whl"
-            },
-            {
-                "module": "charset_normalizer",
-                "input_file": "wheels/charset_normalizer-2.0.10-py3-none-any.whl"
-            },
-            {
-                "module": "idna",
-                "input_file": "wheels/idna-3.3-py3-none-any.whl"
-            },
-            {
-                "module": "requests",
-                "input_file": "wheels/requests-2.26.0-py2.py3-none-any.whl"
-            },
-            {
-                "module": "soupsieve",
-                "input_file": "wheels/soupsieve-2.3.1-py3-none-any.whl"
-            },
-            {
-                "module": "urllib3",
-                "input_file": "wheels/urllib3-1.26.8-py2.py3-none-any.whl"
-            }
-        ]
-    }
+  "python_version": "3",
+  "pip_dependencies": {
+    "wheel": [
+      {
+        "module": "beautifulsoup4",
+        "input_file": "wheels/py3/beautifulsoup4-4.9.1-py3-none-any.whl"
+      },
+      {
+        "module": "certifi",
+        "input_file": "wheels/shared/certifi-2021.10.8-py2.py3-none-any.whl"
+      },
+      {
+        "module": "charset_normalizer",
+        "input_file": "wheels/py3/charset_normalizer-2.0.11-py3-none-any.whl"
+      },
+      {
+        "module": "idna",
+        "input_file": "wheels/py3/idna-3.3-py3-none-any.whl"
+      },
+      {
+        "module": "requests",
+        "input_file": "wheels/shared/requests-2.26.0-py2.py3-none-any.whl"
+      },
+      {
+        "module": "simplejson",
+        "input_file": "wheels/py36/simplejson-3.17.5-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+      },
+      {
+        "module": "soupsieve",
+        "input_file": "wheels/py3/soupsieve-2.3.1-py3-none-any.whl"
+      },
+      {
+        "module": "urllib3",
+        "input_file": "wheels/shared/urllib3-1.26.8-py2.py3-none-any.whl"
+      }
+    ]
+  },
+  "pip39_dependencies": {
+    "wheel": [
+      {
+        "module": "beautifulsoup4",
+        "input_file": "wheels/py3/beautifulsoup4-4.9.1-py3-none-any.whl"
+      },
+      {
+        "module": "certifi",
+        "input_file": "wheels/shared/certifi-2021.10.8-py2.py3-none-any.whl"
+      },
+      {
+        "module": "charset_normalizer",
+        "input_file": "wheels/py3/charset_normalizer-2.0.11-py3-none-any.whl"
+      },
+      {
+        "module": "idna",
+        "input_file": "wheels/py3/idna-3.3-py3-none-any.whl"
+      },
+      {
+        "module": "requests",
+        "input_file": "wheels/shared/requests-2.26.0-py2.py3-none-any.whl"
+      },
+      {
+        "module": "simplejson",
+        "input_file": "wheels/py39/simplejson-3.17.5-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+      },
+      {
+        "module": "soupsieve",
+        "input_file": "wheels/py3/soupsieve-2.3.1-py3-none-any.whl"
+      },
+      {
+        "module": "urllib3",
+        "input_file": "wheels/shared/urllib3-1.26.8-py2.py3-none-any.whl"
+      }
+    ]
+  }
 }

--- a/pre-commit/tests/data/py3-app/requirements.txt
+++ b/pre-commit/tests/data/py3-app/requirements.txt
@@ -1,2 +1,3 @@
 beautifulsoup4==4.9.1
 requests==2.26.0
+simplejson==3.17.5

--- a/pre-commit/tests/test_package_app_dependencies.py
+++ b/pre-commit/tests/test_package_app_dependencies.py
@@ -11,6 +11,7 @@ PRE_COMMIT_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 @pytest.fixture(scope='function', params=[
     'tests/data/py2-app',
     'tests/data/py3-app',
+    'tests/data/pure-python-py3-app',
     'tests/data/app-with-pip2-pip3-deps'
 ])
 def app_dir(request):


### PR DESCRIPTION
- Generate wheels using python 3.9 as well as python 3.6.
- If there are wheel differences, add 3.9 wheels to the pip39_dependencies key.
- Modularize the pip dependency key checks to easily allow support for new python versions in the future.
- Always generate wheels under respective directory (shared, py3, etc.) without flattening for simplicity.

Tested using:
- Unit tests (which were accordingly updated)
- Manually installed an app and ran tests on an OVA using python 3.9