### PR TITLE
Start-release updates

### DIFF
--- a/github-actions/start-release/tests/data/release_notes/existing_release_notes_md/release_notes/1.0.md
+++ b/github-actions/start-release/tests/data/release_notes/existing_release_notes_md/release_notes/1.0.md
@@ -1,0 +1,2 @@
+* existing note 1
+* existing note 2

--- a/github-actions/start-release/tests/data/release_notes/existing_release_notes_md/release_notes/expected_new_release_notes.html
+++ b/github-actions/start-release/tests/data/release_notes/existing_release_notes_md/release_notes/expected_new_release_notes.html
@@ -1,0 +1,14 @@
+<b>APP_NAME Release Notes - Published by PUBLISHER PUBLISH_DATE</b>
+<br><br>
+<b>Version VERSION - Released PUBLISH_DATE</b>
+<ul>
+<li>existing note</li>
+<li>foo</li>
+<li>bar</li>
+<li>baz</li>
+</ul>
+<b>Version 0.9 - Released January 01, 2019</b>
+<ul>
+    <li>previous release note a</li>
+    <li>previous release note b</li>
+</ul>

--- a/github-actions/start-release/tests/data/release_notes/existing_release_notes_md/release_notes/expected_release_notes.md
+++ b/github-actions/start-release/tests/data/release_notes/existing_release_notes_md/release_notes/expected_release_notes.md
@@ -1,0 +1,5 @@
+* existing note 1
+* existing note 2
+* foo
+* bar
+* baz

--- a/github-actions/start-release/tests/data/release_notes/existing_release_notes_md/release_notes/release_notes.html
+++ b/github-actions/start-release/tests/data/release_notes/existing_release_notes_md/release_notes/release_notes.html
@@ -1,0 +1,11 @@
+<b>App Release Notes - Published by Splunk January 01, 2020</b>
+<br><br>
+<b>Version 1.0 - Released January 01, 2020</b>
+<ul>
+<li>existing note</li>
+</ul>
+<b>Version 0.9 - Released January 01, 2019</b>
+<ul>
+    <li>previous release note a</li>
+    <li>previous release note b</li>
+</ul>

--- a/github-actions/start-release/tests/data/release_notes/existing_release_notes_md/release_notes/unreleased.md
+++ b/github-actions/start-release/tests/data/release_notes/existing_release_notes_md/release_notes/unreleased.md
@@ -1,3 +1,4 @@
+**Unreleased**
 * foo
 * bar
 * baz

--- a/github-actions/start-release/tests/data/release_notes/missing_release_notes_html/release_notes/expected_release_notes.md
+++ b/github-actions/start-release/tests/data/release_notes/missing_release_notes_html/release_notes/expected_release_notes.md
@@ -1,8 +1,3 @@
-**<APP_NAME> Release Notes - Published by <PUBLISHER> <PUBLISH_DATE>**
-
-
-**Version <VERSION> - Released <PUBLISH_DATE>**
-
 * foo
 * bar
 * baz

--- a/github-actions/start-release/tests/data/release_notes/nested_notes/release_notes/expected_release_notes.md
+++ b/github-actions/start-release/tests/data/release_notes/nested_notes/release_notes/expected_release_notes.md
@@ -1,8 +1,3 @@
-**<APP_NAME> Release Notes - Published by <PUBLISHER> <PUBLISH_DATE>**
-
-
-**Version <VERSION> - Released <PUBLISH_DATE>**
-
 * parent
   * child-1
     * grand-child

--- a/github-actions/start-release/tests/test_build_docs.py
+++ b/github-actions/start-release/tests/test_build_docs.py
@@ -20,7 +20,7 @@ FROM_MD_TEST_DATA = [
 ]
 
 FROM_HTML_TEST_DATA = [
-    ("tests/data/build_docs/has_existing_readme_html_and_md", True, [README_MD_ORIGINAL_NAME], [], None),
+    ("tests/data/build_docs/has_existing_readme_html_and_md", True, [], [], None),
     ("tests/data/build_docs/has_existing_readme_html_and_autogen_md", True, [], [README_MD_ORIGINAL_NAME], None),
     ("tests/data/build_docs/has_no_readme", True, [README_OUTPUT_NAME], [], None),
     ("tests/data/build_docs/has_no_readme_set_app_version", True, [README_OUTPUT_NAME], [], "3.0.0")

--- a/github-actions/start-release/tests/test_generate_release_notes.py
+++ b/github-actions/start-release/tests/test_generate_release_notes.py
@@ -24,7 +24,8 @@ def app_json():
 @pytest.fixture(scope='function', params=[
     'tests/data/release_notes/existing_release_notes_html',
     'tests/data/release_notes/missing_release_notes_html',
-    'tests/data/release_notes/nested_notes'
+    'tests/data/release_notes/nested_notes',
+    'tests/data/release_notes/existing_release_notes_md'
 ])
 def app_dir(request):
     return copy_app_dir(request)
@@ -34,11 +35,7 @@ def test_generate_release_notes(app_dir, app_json):
     updates = generate_release_notes(app_dir, APP_VERSION, app_json)
 
     with open(os.path.join(app_dir, 'release_notes/expected_release_notes.md')) as f:
-        assert updates[f'release_notes/{APP_VERSION}.md'] == f.read()\
-            .replace('<APP_NAME>', APP_NAME)\
-            .replace('<VERSION>', APP_VERSION)\
-            .replace('<PUBLISHER>', PUBLISHER) \
-            .replace('<PUBLISH_DATE>', PUBLISH_DATE)
+        assert updates[f'release_notes/{APP_VERSION}.md'] == f.read()
 
     with open(os.path.join(app_dir, 'release_notes/expected_new_release_notes.html')) as f:
         assert updates[f'release_notes/release_notes.html'] == f.read()\


### PR DESCRIPTION
### Notes
- Going forward, start-release will be triggered from tags pushed by the build job, where the build job will create a tag on each run against `next` and will only increment the app version when it detects that the current `app_version` has already been released
- To accompany the changes to the build job, I'm making the following updates to start-release
  - Create a new release notes file for the current `app_version` from `unreleased.md` if doesn't exist, otherwise, append `unreleased.md` to the existing file
  - Do not open a next --> main PR if one is already open
  - Update `build_docs_from_html` to check if the newly built readme differs from the previous readme to prevent empty commits from created
  - Stop generating headers in the markdown release notes for Splunkbase but keep them in the html release notes for Phantom Portal

### Testing
- Additional unit tests
- Example commits made by start-release
  - https://github.com/splunk-soar-connectors/exampleapp/commit/673fac4479ff9b8afa2022263c35e8ec29e30995
  - https://github.com/splunk-soar-connectors/exampleapp/commit/5ca0eb009769a04fe2115ac7f394d58e1b382c2c
- Commit with an associated start-release run triggered from a tag push - https://github.com/splunk-soar-connectors/exampleapp/commit/7d6d18e3d578e8a6e3eac2e909ee3285e9828673  