### PR TITLE
Upgrading Jinja to version 3.0.3

### DIFF
--- a/github-actions/start-release/requirements.txt
+++ b/github-actions/start-release/requirements.txt
@@ -1,4 +1,4 @@
-Jinja2==2.11.3
+Jinja2==3.0.3
 Pygments==2.7.4
 beautifulsoup4==4.9.3
 gh-md-to-html==1.21.1

--- a/pre-commit/tests/data/app-with-pip2-pip3-deps/expected_app_json.out
+++ b/pre-commit/tests/data/app-with-pip2-pip3-deps/expected_app_json.out
@@ -36,7 +36,7 @@
       },
       {
         "module": "charset_normalizer",
-        "input_file": "wheels/py3/charset_normalizer-2.0.11-py3-none-any.whl"
+        "input_file": "wheels/py3/charset_normalizer-2.0.12-py3-none-any.whl"
       },
       {
         "module": "idna",
@@ -64,7 +64,7 @@
       },
       {
         "module": "charset_normalizer",
-        "input_file": "wheels/py3/charset_normalizer-2.0.11-py3-none-any.whl"
+        "input_file": "wheels/py3/charset_normalizer-2.0.12-py3-none-any.whl"
       },
       {
         "module": "idna",

--- a/pre-commit/tests/data/py3-app/expected_app_json.out
+++ b/pre-commit/tests/data/py3-app/expected_app_json.out
@@ -12,7 +12,7 @@
       },
       {
         "module": "charset_normalizer",
-        "input_file": "wheels/py3/charset_normalizer-2.0.11-py3-none-any.whl"
+        "input_file": "wheels/py3/charset_normalizer-2.0.12-py3-none-any.whl"
       },
       {
         "module": "idna",
@@ -48,7 +48,7 @@
       },
       {
         "module": "charset_normalizer",
-        "input_file": "wheels/py3/charset_normalizer-2.0.11-py3-none-any.whl"
+        "input_file": "wheels/py3/charset_normalizer-2.0.12-py3-none-any.whl"
       },
       {
         "module": "idna",


### PR DESCRIPTION
### Notes
- ```jinja=2.11.3``` specifies any version of `markupsafe` [>= 0.23](https://github.com/pallets/jinja/blob/cf215390d4a4d6f0a4de27e2687eed176878f13d/setup.py#L53) but the latest release of `markupsafe` [breaks compatibility](https://github.com/splunk-soar-connectors/ixianpb/runs/5243771498?check_suite_focus=true`) with ```jinja=2.11.3```
- Upgrading Jinja to 3.0.3

### Testing
- Ran start release locally and generated https://github.com/splunk-soar-connectors/ixianpb/commit/768dc23361090e58e275fa2d2f3049dcc6dd9d77