### PR TITLE
Adding custom semgrep rules to cover prodsec questions

### DIFF
--- a/.github/workflows/upload-semgrep-rules.yml
+++ b/.github/workflows/upload-semgrep-rules.yml
@@ -1,0 +1,32 @@
+name: Upload Semgrep Rules
+on: [push]
+env:
+  SEMGREP_DEPLOYMENT_ID: ${{ secrets.SEMGREP_DEPLOYMENT_ID }}
+  SEMGREP_TOKEN: ${{ secrets.SEMGREP_TOKEN }}
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/dev-requirements.txt') }}
+      - name: Install Dependencies
+        run: pip install -r dev-requirements.txt
+      - name: Run Tests
+        run: |
+          semgrep --test semgrep/rules
+  upload-rules:
+    needs: run-tests
+    if: github.ref_name == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Upload Rules
+        run: make semgrep-upload

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -1,8 +1,0 @@
-# Add custom semgrep rules below
-rules:
-- id: eqeq-is-bad
-  pattern: $X == $X
-  message: $X == $X is a useless equality check
-  languages:
-  - python
-  severity: ERROR

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 LINT_CONFIG=$(PWD)/lint-configs/tox.ini
 APP_FOLDER=APP_FOLDER_UNSPECIFIED
 
-SEMGREP_CONFIGS= --config=p/python --config=.semgrep.yml
+SEMGREP_RULES=semgrep/rules
+SEMGREP_CONFIGS= --config=$(SEMGREP_RULES)
 SEMGREP_EXCLUDES=--exclude='*json' --exclude='.html' --exclude='.svg' --exclude='wheels/'
 
 .PHONY: install flake8-check isort-check isort-fix autopep8-fix autopep8-fix-aggressive lint lint-fix lint-fix-aggressive semgrep
@@ -32,5 +33,11 @@ lint-fix: autopep8-fix isort-fix
 
 lint-fix-aggressive: autopep8-fix-aggressive isort-fix
 
-semgrep:
+semgrep-run:
 	semgrep $(SEMGREP_CONFIGS) $(APP_FOLDER) $(SEMGREP_EXCLUDES)
+
+semgrep-test:
+	semgrep --test $(SEMGREP_RULES)
+
+semgrep-upload:
+	./semgrep/upload_private_rules.sh

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,4 +2,4 @@ isort==5.8.0
 autopep8==1.5.7
 black==21.6b0
 flake8==3.9.2
-semgrep==0.64.0
+semgrep==0.83.0

--- a/semgrep/README.md
+++ b/semgrep/README.md
@@ -1,0 +1,67 @@
+# Welcome
+This folder contains private semgrep rules defined for connectors in https://github.com/splunk-soar-connectors.
+Before updating or adding a rule, make sure to install semgrep:
+```
+pip install semgrep
+```
+
+# Writing Rules
+See the Semgrep [getting started](https://semgrep.dev/docs/writing-rules/overview/) and
+[pattern syntax](https://semgrep.dev/docs/writing-rules/pattern-syntax/) pages.
+
+# Directory Structure
+When writing a new rule, please place its configuration and test file under 
+`rules/python/category/<rule-file>.yaml` and `rules/python/category/<rule-file>.py` respectively.
+Note that the test for a given rule needs to have the same name as the rule's configuration file minus
+the file extension (eg, `my-rule.yaml`, `my-rule.py`) for the test to be picked up by Semgrep.
+
+# Running Tests
+To test a specific set of rules, run:
+```
+semgrep --test semgrep/rules/python/category
+```
+
+To test all the rules, run:
+```
+semgrep --test semgrep/rules
+```
+
+or
+```
+make semgrep-test
+```
+
+## Test Annotations
+Semgrep provides annotations we can use in our test code to indicate where we are or aren't expecting
+findings. See https://semgrep.dev/docs/writing-rules/testing-rules/ for more details.
+
+# Running Rules
+To run the rules defined here against a connector repo:
+```
+cd <path_to_connector_repo>
+semgrep --config <path_to_dev_cicd_tools>/semgrep/rules
+```
+or 
+```
+export APP_FOLDER=<path_to_connector_repo>
+make semgrep
+```
+
+# Uploading Private Rules
+`upload_private_rules.sh` will upload the rules from every `yaml` file under the `rules` folder
+to the Semgrep registry. Note that the rules will only be visible to members of `splunk-soar-connectors`.
+
+```
+./semgrep/upload_private_rules.sh
+# or ...
+make semgrep-upload
+```
+
+To upload a specific a ruleset under the path `rules/python/category/ruleset.yaml`:
+```
+docker pull returntocorp/semgrep-upload:latest
+docker run -v "$(pwd)":/temp \
+    -e SEMGREP_UPLOAD_DEPLOYMENT="$SEMGREP_DEPLOYMENT_ID" \
+    -e SEMGREP_TOKEN="$SEMGREP_TOKEN" \
+    returntocorp/semgrep-upload:latest "/temp/rules/python/category/ruleset.yaml"
+```

--- a/semgrep/rules/python/filesystem/filesystem_access.py
+++ b/semgrep/rules/python/filesystem/filesystem_access.py
@@ -1,0 +1,34 @@
+import os
+import pathlib
+import shutil as util
+import tempfile as temp
+
+
+class Connector:
+    def __init__(self):
+        # ok: filesystem-access
+        self.base_name = os.path.basename('/foo/bar/baz')
+
+        # ruleid: filesystem-access
+        with open('foobar') as f:
+            f.read()
+        # ruleid: filesystem-access
+        with open('foobar', 'w') as f:
+            f.write('foobar')
+
+        # ruleid: filesystem-access
+        pathlib.Path('foobar')
+        # ruleid: filesystem-access
+        util.rmtree('foobar')
+        # ruleid: filesystem-access
+        temp.mkdtemp()
+
+
+if __name__ == '__main__':
+    # ok: filesystem-access
+    with open('foobar') as f:
+        f.read()
+
+    # ok: filesystem-access
+    with open('foobar', 'w') as f:
+        f.write('foobar')

--- a/semgrep/rules/python/filesystem/filesystem_access.yaml
+++ b/semgrep/rules/python/filesystem/filesystem_access.yaml
@@ -1,0 +1,20 @@
+rules:
+  - id: filesystem-access
+    patterns:
+      - pattern-either:
+        - pattern: open(...)
+        - pattern: shutil.$FUNC(...)
+        - pattern: tempfile.$FUNC(...)
+        - pattern: os.$FUNC(...)
+        - pattern: pathlib.$FUNC(...)
+      - pattern-not: import os.path
+      - pattern-not-inside: |
+          if __name__ == '__main__':
+            ...
+      - pattern-not-inside: |
+          def main(...):
+            ...
+    message: |
+        Detected APIs used to access the filesystem other than the logging and state serialization APIs provided by BaseConnector.
+    languages: [python]
+    severity: ERROR

--- a/semgrep/rules/python/logging/logging_sensitive_data.py
+++ b/semgrep/rules/python/logging/logging_sensitive_data.py
@@ -1,0 +1,42 @@
+import logging
+
+
+class Connector:
+    def main(self):
+        # ruleid: logging-sensitive-data
+        print(self._secret)
+        # ok: logging-sensitive-data
+        print('foobar')
+
+        # ruleid: logging-sensitive-data
+        logging.debug(self._secret)
+        # ruleid: logging-sensitive-data
+        logging.info(self._secret)
+        # ruleid: logging-sensitive-data
+        logging.warning(self._secret)
+        # ruleid: logging-sensitive-data
+        logging.error(self._secret)
+        # ruleid: logging-sensitive-data
+        logging.critical(self._secret)
+        # ruleid: logging-sensitive-data
+        logging.fatal(self._secret)
+        # ruleid: logging-sensitive-data
+        logging.exception(self._secret)
+        # ruleid: logging-sensitive-data
+        logging.log(logging.INFO, self._secret)
+        # ok: logging-sensitive-data
+        logging.info('foobar')
+
+        # ruleid: logging-sensitive-data
+        self.debug_print(self._secret)
+        # ruleid: logging-sensitive-data
+        self.error_print(self._secret)
+        # ruleid: logging-sensitive-data
+        self.save_progress(self._secret)
+        # ruleid: logging-sensitive-data
+        self.send_progress(self._secret)
+        # ok: logging-sensitive-data
+        self.send_progress('foobar')
+
+
+

--- a/semgrep/rules/python/logging/logging_sensitive_data.yaml
+++ b/semgrep/rules/python/logging/logging_sensitive_data.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: logging-sensitive-data
+    patterns:
+      - pattern-either:
+        - pattern: self.$FUNC($X)
+        - pattern: $FUNC($X)
+        - pattern: logging.$FUNC(..., $X)
+      - metavariable-regex:
+          metavariable: $FUNC
+          regex: '(print|log|debug|info|warning|error|fatal|critical|exception|debug_print|error_print|save_progress|send_progress)'
+      - metavariable-regex:
+          metavariable: $X
+          regex: '.*(secret|token|key|password).*'
+    message: |
+      Detects sensitive data (eg, API keys, passwords, etc) logged by a connector.
+    languages: [python]
+    severity: ERROR

--- a/semgrep/rules/python/logging/soar_standard_logging.py
+++ b/semgrep/rules/python/logging/soar_standard_logging.py
@@ -1,0 +1,18 @@
+import logging as logger
+
+from phantom import BaseConnector as Base
+
+
+class Connector(Base):
+    def __init__(self):
+        # ruleid: soar-standard-logging
+        print('foobar')
+        # ruleid: soar-standard-logging
+        logger.info('foobar')
+        # ruleid: soar-standard-logging
+        logger.getLogger().info('foobar')
+
+        # ok: soar-standard-logging
+        self.debug_print('foobar')
+        # ok: soar-standard-logging
+        self.save_progress('foobar')

--- a/semgrep/rules/python/logging/soar_standard_logging.yaml
+++ b/semgrep/rules/python/logging/soar_standard_logging.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: soar-standard-logging
+    patterns:
+      - pattern-inside: |
+          import phantom
+          ...
+          class $CLASS(phantom.BaseConnector):
+            ...
+      - pattern-either:
+        - pattern: |
+            print(...)
+        - pattern: |
+            logging.$FUNC(...)
+    message: |
+        Only the logging methods provided by BaseConnector should be used for logging within a connector implementation.
+    languages: [python]
+    severity: WARNING

--- a/semgrep/rules/python/secrets/request_sensitive_data.py
+++ b/semgrep/rules/python/secrets/request_sensitive_data.py
@@ -1,0 +1,34 @@
+import requests as r
+
+
+class Connector:
+    def main(self, method='get'):
+        # ruleid: request-sensitive-data
+        req_method = getattr(r, method)
+        req_method('https://api.com/resource?auth={}'.format(self._secret))
+
+        # ruleid: request-sensitive-data
+        req_method = getattr(r, method)
+        req_method('https://api.com/resource?auth={}'.format(self._api_token))
+
+        # ruleid: request-sensitive-data
+        req_method = getattr(r, method)
+        req_method('https://api.com/resource?auth={}'.format(self._api_key))
+
+        # ruleid: request-sensitive-data
+        req_method = getattr(r, method)
+        req_method('https://api.com/resource?auth={}'.format(self._password))
+
+        # ruleid: request-sensitive-data
+        r.get(f'https://api.com/resource?auth={self._secret}')
+        # ruleid: request-sensitive-data
+        r.get(f'https://api.com/resource?auth={self._api_token}')
+        # ruleid: request-sensitive-data
+        r.get(f'https://api.com/resource?auth={self._api_key}')
+        # ruleid: request-sensitive-data
+        r.get(f'https://api.com/resource?auth={self._password}')
+
+        # ok: request-sensitive-data
+        r.get('https://api.com/resource', headers={
+            'Authorization': f'Bearer {self._api_token}'
+        })

--- a/semgrep/rules/python/secrets/request_sensitive_data.yaml
+++ b/semgrep/rules/python/secrets/request_sensitive_data.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: request-sensitive-data
+    patterns:
+      - pattern-either:
+        - pattern: |
+            requests.$FUNC($X, ...)
+        - pattern: |
+            $FUNC = getattr(requests, ...)
+            ...
+            $FUNC($X, ...)
+      - metavariable-regex:
+          metavariable: $X
+          regex: '.*(secret|token|key|password).*'
+    message: |
+        Detects sensitive data (eg, API keys, passwords, etc) included in the URL of HTTP requests.
+    languages: [python]
+    severity: ERROR

--- a/semgrep/upload_private_rules.sh
+++ b/semgrep/upload_private_rules.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+if [ -z "$SEMGREP_DEPLOYMENT_ID" ] || [ -z "$SEMGREP_TOKEN" ]; then
+  echo 'SEMGREP_DEPLOYMENT_ID and SEMGREP_TOKEN must be set'
+  exit 1
+fi
+
+if ! docker &> /dev/null; then
+  echo 'Please make sure Docker is installed and running'
+  exit 1
+fi
+
+SEMGREP_IMAGE='returntocorp/semgrep-upload:latest'
+docker pull "$SEMGREP_IMAGE"
+
+cd "$SCRIPT_DIR"
+find rules -path '**/*.yml' -or -path '**/*.yaml' | while read -r file ; do
+  echo "Uploading $file..."
+  docker run -v "$(pwd)":/temp \
+    -e SEMGREP_UPLOAD_DEPLOYMENT="$SEMGREP_DEPLOYMENT_ID" \
+    -e SEMGREP_TOKEN="$SEMGREP_TOKEN" \
+    "$SEMGREP_IMAGE" "/temp/$file"
+done


### PR DESCRIPTION
### Notes
- Adding custom semgrep rules to cover the ProdSec questionnaire questions that we couldn't find an existing rule for
   - File system access outside of using standard `BaseConnector` APIs
   - Exposing potential secrets in the URLs of HTTP requests
   - Logging of potential secrets
   - 'Non-standard' logging outside using the `BaseConnector` logging APIs
- Workflow file and upload script to upload the rules from this repo to https://semgrep.dev/r
   - rules are prefixed with the `splunk-soar-connectors.` namespace and are only visible to members of the org - https://semgrep.dev/r?q=splunk-soar-connectors