### PR TITLE
Semgrep rule to detect potential xss in rest handlers

### DIFF
--- a/semgrep/rules/python/xss/reflected_xss.py
+++ b/semgrep/rules/python/xss/reflected_xss.py
@@ -1,0 +1,56 @@
+import json
+
+from django.http import HttpResponse
+
+
+def dangerously_handle_request(request):
+    try:
+        payload = json.loads(request.POST.get('payload'))
+    except Exception as e:
+        # ruleid: reflected-cross-site-scripting
+        return HttpResponse(f'error: {e}', status=500)
+
+    # ruleid: reflected-cross-site-scripting
+    return HttpResponse(payload.get('foobar'), content_type = "text/html")
+
+
+def safely_handle_request(request):
+    try:
+        payload = json.loads(request.POST.get('payload'))
+    except Exception as e:
+        # ok: reflected-cross-site-scripting
+        return HttpResponse(f'error: {e}', content_type='text/plain', status=500)
+
+    # ok: reflected-cross-site-scripting
+    return HttpResponse(payload.get('foobar'), content_type = "text/plain")
+
+
+class RequestHandler:
+    def dangerously_handle_request(self):
+        try:
+            state = json.loads(self._request.GET.get('state'))
+        except Exception as e:
+            # ruleid: reflected-cross-site-scripting
+            return HttpResponse(f'error: {e}', status=500)
+
+        # ruleid: reflected-cross-site-scripting
+        return HttpResponse(state, content_type="text/html")
+
+    def safely_handle_request(self):
+        try:
+            state = json.loads(self._request.GET.get('state'))
+        except Exception as e:
+            # ok: reflected-cross-site-scripting
+            return HttpResponse(f'error: {e}', content_type='text/plain', status=500)
+
+        # ok: reflected-cross-site-scripting
+        return HttpResponse(state, content_type="text/plain")
+
+
+from phantom import BaseConnector as Base
+
+
+class Connector(Base):
+    def handle_request(self):
+        # ok: reflected-cross-site-scripting
+        return HttpResponse('foobar')

--- a/semgrep/rules/python/xss/reflected_xss.py
+++ b/semgrep/rules/python/xss/reflected_xss.py
@@ -45,12 +45,3 @@ class RequestHandler:
 
         # ok: reflected-cross-site-scripting
         return HttpResponse(state, content_type="text/plain")
-
-
-from phantom import BaseConnector as Base
-
-
-class Connector(Base):
-    def handle_request(self):
-        # ok: reflected-cross-site-scripting
-        return HttpResponse('foobar')

--- a/semgrep/rules/python/xss/reflected_xss.yaml
+++ b/semgrep/rules/python/xss/reflected_xss.yaml
@@ -1,0 +1,24 @@
+rules:
+  - id: reflected-cross-site-scripting
+    patterns:
+      - pattern-not-inside: |
+          import phantom
+          ...
+          class $CLASS(phantom.BaseConnector):
+            ...
+      - pattern-either:
+        - pattern-inside: |
+            def $FUNC($REQUEST, ...):
+              ...
+        - pattern-inside: |
+            def $FUNC(self, ...):
+              ...
+      - pattern: |
+          return django.http.HttpResponse($C, ...)
+      - pattern-not: |
+         return django.http.HttpResponse($C, ..., content_type='text/plain', ...)
+    message: |
+        Verifies that a SOAR Connector REST handler sets the content_type of their response to 'text/plain'
+        to prevent potential reflected cross site scripting.
+    languages: [python]
+    severity: ERROR

--- a/semgrep/rules/python/xss/reflected_xss.yaml
+++ b/semgrep/rules/python/xss/reflected_xss.yaml
@@ -1,22 +1,10 @@
 rules:
   - id: reflected-cross-site-scripting
     patterns:
-      - pattern-not-inside: |
-          import phantom
-          ...
-          class $CLASS(phantom.BaseConnector):
-            ...
-      - pattern-either:
-        - pattern-inside: |
-            def $FUNC($REQUEST, ...):
-              ...
-        - pattern-inside: |
-            def $FUNC(self, ...):
-              ...
       - pattern: |
-          return django.http.HttpResponse($C, ...)
+          django.http.HttpResponse($C, ...)
       - pattern-not: |
-         return django.http.HttpResponse($C, ..., content_type='text/plain', ...)
+         django.http.HttpResponse($C, ..., content_type='text/plain', ...)
     message: |
         Verifies that a SOAR Connector REST handler sets the content_type of their response to 'text/plain'
         to prevent potential reflected cross site scripting.


### PR DESCRIPTION
### Notes
- Adding a semgrep rule to detect potential XSS from the return values of [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
  - see https://splunk.atlassian.net/browse/PAPP-10251 for an example
 - The OAuth/SAML question in the ProdSec questionnaire was actually intended to catch this issue