### PR TITLE
Replace ignore with extend-ignore in tox.ini

### DIFF
--- a/lint-configs/tox.ini
+++ b/lint-configs/tox.ini
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 145
 max-complexity = 28
-ignore = F403,E128,E126,E111,E121,E127,E731,E201,E202,F405,E722,D,W292
+extend-ignore = F403,E128,E126,E111,E121,E127,E731,E201,E202,F405,E722,D,W292
 
 [isort]
 line_length = 145


### PR DESCRIPTION
### Notes
- Updating `ignore` in `tox.ini` to be `extend-ignore` to extend from flake8's default set of ignored codes 
- https://stackoverflow.com/questions/67942075/w504-line-break-after-binary-operator