### PR TITLE
Updating resume/review release actions to update commit status

### DIFF
--- a/.github/workflows/review-release.yml
+++ b/.github/workflows/review-release.yml
@@ -1,0 +1,57 @@
+name: Review Release
+on:
+  workflow_call:
+    inputs:
+      task_token:
+        type: string
+        required: true
+        description: 'Task token to resume the paused StepFunction workflow orchestrating the app release'
+      aws_region:
+        type: string
+        required: false
+        description: 'Region of the workflow'
+        default: 'us-west-2'
+    secrets:
+      resume_release_role_arn:
+        required: true
+jobs:
+  review_release:
+    runs-on: ubuntu-latest
+    outputs:
+      manual_review_required: ${{ steps.review_release.outputs.manual_review_required }}
+    steps:
+      - id: review_release
+        uses: 'phantomcyber/dev-cicd-tools/github-actions/review-release@release'
+        with:
+          github_token: ${{ secrets.github_token }}
+  manual_review:
+    needs: [review_release]
+    if: needs.review_release.outputs.manual_review_required == 'true'
+    runs-on: ubuntu-latest
+    environment: prod
+    steps:
+      - run: exit 0
+  approve_release:
+    needs: [review_release, manual_review]
+    if: always() && (needs.manual_review.result == 'success' || (needs.review_release.result == 'success' && needs.manual_review.result == 'skipped'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: 'phantomcyber/dev-cicd-tools/github-actions/resume-release@release'
+        with:
+          github_token: ${{ secrets.github_token }}
+          approved: true
+          task_token: ${{ inputs.task_token }}
+          iam_role_arn: ${{ secrets.resume_release_role_arn }}
+          aws_region: ${{ inputs.aws_region }}
+  reject_release:
+    needs: [manual_review]
+    if: always() && needs.manual_review.result == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: 'phantomcyber/dev-cicd-tools/github-actions/resume-release@release'
+        with:
+          github_token: ${{ secrets.github_token }}
+          approved: false
+          task_token: ${{ inputs.task_token }}
+          iam_role_arn: ${{ secrets.resume_release_role_arn }}
+          aws_region: ${{ inputs.aws_region }}

--- a/github-actions/resume-release/action.yml
+++ b/github-actions/resume-release/action.yml
@@ -1,6 +1,9 @@
 name: 'Resume Release'
 description: 'Resumes the paused StepFunction workflow for a given app release by sending back its approval status.'
 inputs:
+  github_token:
+    description: 'Token used to authenticate with the GitHub REST API'
+    required: true
   approved:
     description: 'true/false indicating if the release is approved or not'
     required: true
@@ -17,6 +20,36 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.9'
+    - name: 'Check PIP Cache'
+      uses: actions/cache@v2
+      id: cache
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-python39-pip-review-release
+    - name: 'Install Dependencies'
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r "${{ github.action_path }}/../scripts/review_release/requirements.txt"
+    - name: 'Update Commit Status'
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+      shell: bash
+      run: |
+        cd ${{ github.action_path }}/..
+        if [[ ${{ inputs.approved }} == 'true' ]]; then
+          state='pending'
+          description='Pending upload to Splunkbase'
+        else
+          state=failure
+          description='Release rejected'
+        fi
+        python -m scripts.review_release.put_commit_status ${{ github.repository }} ${{ github.sha }} \
+          -s "$state" -d "$description" -t "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
     - name: 'Configure AWS Credentials'
       uses: aws-actions/configure-aws-credentials@v1.6.1
       with:

--- a/github-actions/review-release/action.yml
+++ b/github-actions/review-release/action.yml
@@ -30,6 +30,14 @@ runs:
       uses: actions/checkout@v2
       with:
         ref: ${{ github.ref }}
+    - name: 'Update Commit Status'
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+      shell: bash
+      run: |
+        cd ${{ github.action_path }}/..
+        python -m scripts.review_release.put_commit_status ${{ github.repository }} ${{ github.sha }} \
+          -s pending -d 'Pending review' -t "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
     - name: 'Review Release'
       id: review_release
       env:

--- a/github-actions/scripts/review_release/put_commit_status.py
+++ b/github-actions/scripts/review_release/put_commit_status.py
@@ -1,0 +1,43 @@
+"""
+Sets a commit status for a target commit on an app repo
+"""
+import argparse
+import logging
+import os
+import sys
+
+from github import Github
+
+DEFAULT_COMMIT_STATUS = 'App Release'
+
+
+def parse_args():
+    help_str = ' '.join(line.strip() for line in __doc__.splitlines())
+    argparser = argparse.ArgumentParser(description=help_str)
+    argparser.add_argument('app_repo', type=str, help='Repo name including the owner')
+    argparser.add_argument('commit_sha', type=str, help='Hash of the commit to put the status for')
+    argparser.add_argument('-s', '--state', required=True, type=str,
+                           choices=['pending', 'success', 'failure'], help='State to assign the commit status')
+    argparser.add_argument('-n', '--name', type=str, help='Name of the commit status', default=DEFAULT_COMMIT_STATUS)
+    argparser.add_argument('-d', '--description', type=str, help='Optional status description')
+    argparser.add_argument('-t', '--target_url', type=str, help='Optional url to include in the commit status')
+
+    return argparser.parse_args()
+
+
+def main(args):
+    github = Github(login_or_token=os.environ['GITHUB_TOKEN'])
+    repo = github.get_repo(args.app_repo)
+    commit = repo.get_commit(args.commit_sha)
+
+    status = commit.create_status(context=args.name,
+                                  state=args.state,
+                                  description=args.description,
+                                  target_url=args.target_url)
+    logging.info('Created commit status: %s', status.url)
+
+
+if __name__ == '__main__':
+    logging.getLogger().setLevel(logging.INFO)
+    sys.exit(main(parse_args()))
+


### PR DESCRIPTION
### Notes
- Updating the review/resume release actions to update the `App Release` commit status for the target app
  - both actions set the target_url of the commit status to the url of the running workflow
  - review-release sets the description to `Pending review`
  - resume-release sets the description to `Pending upload to Splunkbase` or `Release rejected` depending on whether the release was approved or rejected. The commit status state is also set to `failure` if the release was rejected
- Refactoring the `review-release` [workflow](https://github.com/splunk-soar-connectors/.github/blob/main/workflow-templates/review-release.yml) into a [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows) to be stored in this repo

### Testing
- https://github.com/splunk-soar-connectors/exampleapp/actions/runs/2545541120