### PR TITLE
Updating review-release commit status regex

### DIFF
--- a/github-actions/scripts/review_release/main.py
+++ b/github-actions/scripts/review_release/main.py
@@ -11,13 +11,14 @@ from github import Github
 
 from ..common import get_app_json
 
-COMMIT_STATUS_PATTERN = re.compile(r'(AWS CodeBuild (BuildBatch )?us-west-[1-2] )?\(?(?P<context>[\w-]+)\)?')
+COMMIT_STATUS_PATTERN = re.compile(r'(AWS CodeBuild (BuildBatch )?us-west-[1-2] )?\(?(?P<context>[\w\s-]+)\)?')
 REQUIRED_COMMIT_STATUSES = [
+    'Static Tests',
+    'Compile Tests',
+    'app-integration-tests',
+    'sanity-tests',
     'prodsec-scans',
-    'build-app',
-    'static-tests',
-    'integration-tests',
-    'sanity-tests'
+    'build-app'
 ]
 SPLUNK_BASE_API_URL = os.getenv('SPLUNK_BASE_API_URL', 'https://splunkbase.splunk.com/api/v2/apps')
 SPLUNK_SUPPORT_TAG = 'splunk'

--- a/github-actions/scripts/review_release/main.py
+++ b/github-actions/scripts/review_release/main.py
@@ -11,7 +11,7 @@ from github import Github
 
 from ..common import get_app_json
 
-COMMIT_STATUS_PATTERN = re.compile(r'AWS CodeBuild (BuildBatch )?us-west-[1-2] \((?P<context>.+)\)')
+COMMIT_STATUS_PATTERN = re.compile(r'(AWS CodeBuild (BuildBatch )?us-west-[1-2] )?\(?(?P<context>[\w-]+)\)?')
 REQUIRED_COMMIT_STATUSES = [
     'prodsec-scans',
     'build-app',


### PR DESCRIPTION
### Notes
- We explicitly set the commit status for some our CodeBuild projects (eg, static tests, compile tests)
- Updating the commit status regex used by the `review-release` action to make the `AWS CodeBuild` prefix optional

### Testing
- Updated unit tests