### PR TITLE
Check that splunk base data is not empty

### DIFF
--- a/github-actions/scripts/review_release/main.py
+++ b/github-actions/scripts/review_release/main.py
@@ -45,7 +45,7 @@ def review_release(app_repo, app_dir_path, release_git_ref):
     splunk_base_data = _get_splunk_base_data(app_json['appid'])
 
     new_release_splunk_supported = app_json['publisher'].lower() == SPLUNK_SUPPORT_TAG
-    curr_splunk_supported = splunk_base_data['support'] == SPLUNK_SUPPORT_TAG
+    curr_splunk_supported = splunk_base_data and splunk_base_data['support'] == SPLUNK_SUPPORT_TAG
 
     if curr_splunk_supported and new_release_splunk_supported:
         logging.info('Found %s to be Splunk supported app', app_repo)


### PR DESCRIPTION
For new apps, `splunk_base_data` will be None, however we were trying to index into the result regardless: https://github.com/splunk-soar-connectors/splunkitsi/runs/7577531943?check_suite_focus=true#step:10:611

Add a check that it's defined before trying to index into the value.