### PR TITLE
Bump python version in setup-python

### DIFF
--- a/github-actions/lint/action.yml
+++ b/github-actions/lint/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.6'
+        python-version: '3.9'
     - name: 'Check PIP Cache'
       uses: actions/cache@v2
       id: cache

--- a/github-workflows/.github/workflows/python-package.yml
+++ b/github-workflows/.github/workflows/python-package.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6]
+        python-version: [3.9]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Python 3.6 is EOL and no longer works per https://github.com/actions/setup-python/issues/561