### PR TITLE
PAPP-28462: Update deprecated versions

### DIFF
--- a/.github/workflows/test-package-app-dependencies.yml
+++ b/.github/workflows/test-package-app-dependencies.yml
@@ -6,7 +6,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/test-review-release.yml
+++ b/.github/workflows/test-review-release.yml
@@ -10,7 +10,7 @@ jobs:
         run: |
           echo "REQUIREMENTS_FILE_PATH=github-actions/scripts/review_release/requirements.txt" >> $GITHUB_ENV
           echo "DEV_REQUIREMENTS_FILE_PATH=github-actions/scripts/dev-requirements.txt" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/test-start-release.yml
+++ b/.github/workflows/test-start-release.yml
@@ -6,7 +6,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -20,7 +20,7 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y tidy
           wget https://github.com/jgm/pandoc/releases/download/2.16.2/pandoc-2.16.2-1-amd64.deb
-          sudo dpkg -i pandoc-2.16.2-1-amd64.deb          
+          sudo dpkg -i pandoc-2.16.2-1-amd64.deb
           python -m pip install --upgrade pip
           pip install -r github-actions/start-release/requirements.txt
           pip install -r github-actions/start-release/dev-requirements.txt

--- a/.github/workflows/upload-semgrep-rules.yml
+++ b/.github/workflows/upload-semgrep-rules.yml
@@ -7,7 +7,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -27,6 +27,6 @@ jobs:
     if: github.ref_name == 'main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Upload Rules
         run: make semgrep-upload

--- a/github-actions/review-release/action.yml
+++ b/github-actions/review-release/action.yml
@@ -27,7 +27,7 @@ runs:
         python -m pip install --upgrade pip
         pip install -r "${{ github.action_path }}/../scripts/review_release/requirements.txt"
     - name: Checkout App Repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.ref }}
     - name: 'Update Commit Status'

--- a/github-actions/review-release/action.yml
+++ b/github-actions/review-release/action.yml
@@ -49,9 +49,9 @@ runs:
         exit_code=0
         python -m scripts.review_release.main || exit_code=$?
         if [[ $exit_code -eq 0 ]]; then
-          echo '::set-output name=manual_review_required::false'
+          echo "{manual_review_required}={false}" >> $GITHUB_OUTPUT
         elif [[ $exit_code -eq 1 ]]; then
-          echo '::set-output name=manual_review_required::true'
+          echo "{manual_review_required}={true}" >> $GITHUB_OUTPUT
         else
           exit $exit_code
         fi

--- a/github-workflows/.github/workflows/python-package.yml
+++ b/github-workflows/.github/workflows/python-package.yml
@@ -24,9 +24,9 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Checkout tools repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: ${{ env.CI_TOOLS_REPO }}
         path: ${{ env.CI_TOOLS_DIR }}

--- a/pre-commit/dev-requirements.txt
+++ b/pre-commit/dev-requirements.txt
@@ -1,1 +1,9 @@
+attrs==21.2.0
+iniconfig==1.1.1
+jsondiff==2.0.0
+packaging==21.2
+pluggy==0.13.1
+py==1.11.0
+pyparsing==2.4.7
 pytest==6.2.4
+toml==0.10.2

--- a/pre-commit/tests/data/pure-python-py3-app/expected_app_json.out
+++ b/pre-commit/tests/data/pure-python-py3-app/expected_app_json.out
@@ -28,7 +28,7 @@
             },
             {
                 "module": "soupsieve",
-                "input_file": "wheels/py3/soupsieve-2.4-py3-none-any.whl"
+                "input_file": "wheels/py3/soupsieve-2.4.1-py3-none-any.whl"
             }
         ]
     }

--- a/pre-commit/tests/data/py3-app/expected_app_json.out
+++ b/pre-commit/tests/data/py3-app/expected_app_json.out
@@ -64,7 +64,7 @@
             },
             {
                 "module": "soupsieve",
-                "input_file": "wheels/py3/soupsieve-2.4-py3-none-any.whl"
+                "input_file": "wheels/py3/soupsieve-2.4.1-py3-none-any.whl"
             },
             {
                 "module": "urllib3",

--- a/pre-commit/tests/test_package_app_dependencies.py
+++ b/pre-commit/tests/test_package_app_dependencies.py
@@ -4,6 +4,7 @@ import shutil
 import subprocess
 
 import pytest
+from jsondiff import diff
 
 PRE_COMMIT_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
@@ -52,7 +53,8 @@ def test_app_with_pip_dependencies(app_dir):
 
     with open(app_json) as actual_f, open(expected_app_json) as expected_f:
         actual = json.load(actual_f)
-        assert actual == json.load(expected_f)
+        expected = json.load(expected_f)
+        assert actual == expected, f'Diff: {json.dumps(diff(expected, actual), indent=2)}'
 
         for whl in actual['pip_dependencies']['wheel']:
             assert os.path.exists(os.path.join(app_dir, whl['input_file']))


### PR DESCRIPTION
Update deprecated GitHub features found in warnings on release workflow: https://github.com/splunk-soar-connectors/splunk/actions/runs/4732732321

- Upgrade uses of checkout v2 to checkout v3 which uses node 16: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
- Update uses of `save-output` to use the new format: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/