### PR TITLE
[Feature] Custom docker image

### DIFF
--- a/pre-commit/package_app_dependencies
+++ b/pre-commit/package_app_dependencies
@@ -3,7 +3,23 @@
 APP_DIR=$(pwd)
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-IMAGE="${1-quay.io/pypa/manylinux2014_x86_64}"
+IMAGE="quay.io/pypa/manylinux2014_x86_64"
+DOCKERFILE=""
+
+while getopts 'i:d:' flag; do
+  case "${flag}" in
+    i) IMAGE="${OPTARG}"  ;;
+    d) DOCKERFILE="${OPTARG}" ;;
+  esac
+done
+
+function prepare_docker_image(){
+  if [[ $DOCKERFILE != "" ]]; then
+      IMAGE="$(basename $(dirname $APP_DIR))/$(basename $APP_DIR)"
+      echo "Creating image from context $DOCKERFILE, tag: $IMAGE"
+      docker build -t $IMAGE -f $DOCKERFILE $APP_DIR
+  fi
+}
 
 function package_py3_app_dependencies() {
   PYTHON_VERSION_STRING=$1
@@ -44,5 +60,6 @@ fi
 
 pip39_dependencies_key='pip39_dependencies'
 
+prepare_docker_image
 package_py3_app_dependencies 'cp36-cp36m' $pip3_dependencies_key
 package_py3_app_dependencies 'cp39-cp39' $pip39_dependencies_key

--- a/pre-commit/package_app_dependencies
+++ b/pre-commit/package_app_dependencies
@@ -3,11 +3,13 @@
 APP_DIR=$(pwd)
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
+IMAGE="${1-quay.io/pypa/manylinux2014_x86_64}"
+
 function package_py3_app_dependencies() {
   PYTHON_VERSION_STRING=$1
   PIP_DEPENDENCIES_KEY=$2
   docker run --rm -v "$APP_DIR":/src -v "$SCRIPT_DIR":/pre-commit/ -w "$SCRIPT_DIR" \
-    quay.io/pypa/manylinux2014_x86_64 /bin/bash -c \
+    "$IMAGE" /bin/bash -c \
      "/opt/python/cp39-cp39/bin/python /pre-commit/package_app_dependencies.py \
      /src /opt/python/$PYTHON_VERSION_STRING/bin/pip $PIP_DEPENDENCIES_KEY --repair_wheels"
 }

--- a/pre-commit/package_app_dependencies
+++ b/pre-commit/package_app_dependencies
@@ -19,6 +19,8 @@ function prepare_docker_image(){
       echo "Creating image from context $DOCKERFILE, tag: $IMAGE"
       docker build -t $IMAGE -f $DOCKERFILE $APP_DIR
   fi
+      echo "Using image: $IMAGE"
+
 }
 
 function package_py3_app_dependencies() {

--- a/pre-commit/tests/data/pure-python-py3-app/Dockerfile.wheels
+++ b/pre-commit/tests/data/pure-python-py3-app/Dockerfile.wheels
@@ -1,0 +1,1 @@
+FROM quay.io/pypa/manylinux2014_x86_64

--- a/pre-commit/tests/data/pure-python-py3-app/expected_app_json.out
+++ b/pre-commit/tests/data/pure-python-py3-app/expected_app_json.out
@@ -28,7 +28,7 @@
             },
             {
                 "module": "soupsieve",
-                "input_file": "wheels/py3/soupsieve-2.4.1-py3-none-any.whl"
+                "input_file": "wheels/py3/soupsieve-2.5-py3-none-any.whl"
             }
         ]
     }

--- a/pre-commit/tests/data/py3-app/Dockerfile.wheels
+++ b/pre-commit/tests/data/py3-app/Dockerfile.wheels
@@ -1,0 +1,1 @@
+FROM quay.io/pypa/manylinux2014_x86_64

--- a/pre-commit/tests/data/py3-app/expected_app_json.out
+++ b/pre-commit/tests/data/py3-app/expected_app_json.out
@@ -8,7 +8,7 @@
             },
             {
                 "module": "certifi",
-                "input_file": "wheels/py3/certifi-2022.12.7-py3-none-any.whl"
+                "input_file": "wheels/py3/certifi-2023.11.17-py3-none-any.whl"
             },
             {
                 "module": "charset_normalizer",
@@ -16,7 +16,7 @@
             },
             {
                 "module": "idna",
-                "input_file": "wheels/py3/idna-3.4-py3-none-any.whl"
+                "input_file": "wheels/py3/idna-3.6-py3-none-any.whl"
             },
             {
                 "module": "requests",
@@ -32,7 +32,7 @@
             },
             {
                 "module": "urllib3",
-                "input_file": "wheels/shared/urllib3-1.26.15-py2.py3-none-any.whl"
+                "input_file": "wheels/shared/urllib3-1.26.18-py2.py3-none-any.whl"
             }
         ]
     },
@@ -44,7 +44,7 @@
             },
             {
                 "module": "certifi",
-                "input_file": "wheels/py3/certifi-2022.12.7-py3-none-any.whl"
+                "input_file": "wheels/py3/certifi-2023.11.17-py3-none-any.whl"
             },
             {
                 "module": "charset_normalizer",
@@ -52,7 +52,7 @@
             },
             {
                 "module": "idna",
-                "input_file": "wheels/py3/idna-3.4-py3-none-any.whl"
+                "input_file": "wheels/py3/idna-3.6-py3-none-any.whl"
             },
             {
                 "module": "requests",
@@ -68,7 +68,7 @@
             },
             {
                 "module": "urllib3",
-                "input_file": "wheels/shared/urllib3-1.26.15-py2.py3-none-any.whl"
+                "input_file": "wheels/shared/urllib3-1.26.18-py2.py3-none-any.whl"
             }
         ]
     }

--- a/pre-commit/tests/data/py3-app/expected_app_json.out
+++ b/pre-commit/tests/data/py3-app/expected_app_json.out
@@ -64,7 +64,7 @@
             },
             {
                 "module": "soupsieve",
-                "input_file": "wheels/py3/soupsieve-2.4.1-py3-none-any.whl"
+                "input_file": "wheels/py3/soupsieve-2.5-py3-none-any.whl"
             },
             {
                 "module": "urllib3",

--- a/pre-commit/tests/test_package_app_dependencies.py
+++ b/pre-commit/tests/test_package_app_dependencies.py
@@ -4,6 +4,7 @@ import shutil
 import subprocess
 
 import pytest
+from uuid import uuid4
 from jsondiff import diff
 
 PRE_COMMIT_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -28,12 +29,13 @@ def app_dir(request):
         os.rename(app_json_copy, app_json)
 
     app_dir = request.param
+    backup_uid = uuid4().hex
 
     wheels_dir = os.path.join(app_dir, 'wheels')
-    wheels_dir_copy = os.path.join(app_dir, 'wheels-copy')
+    wheels_dir_copy = os.path.join(app_dir, f'wheels-copy-{backup_uid}')
 
     app_json = os.path.join(app_dir, 'app.json')
-    app_json_copy = os.path.join(app_dir, 'app_json_copy.txt')
+    app_json_copy = os.path.join(app_dir, f'app_json_copy_{backup_uid}.txt')
 
     backup_files()
     request.addfinalizer(restore_files)

--- a/pre-commit/tests/test_package_app_dependencies.py
+++ b/pre-commit/tests/test_package_app_dependencies.py
@@ -47,7 +47,6 @@ def app_dir(request):
 def test_app_with_pip_dependencies(flags, app_dir):
     app_json = os.path.join(app_dir, 'app.json')
     expected_app_json = os.path.join(app_dir, 'expected_app_json.out')
-    print(os.path.join(PRE_COMMIT_DIR, 'package_app_dependencies'), *flags)
     result = subprocess.run([os.path.join(PRE_COMMIT_DIR, 'package_app_dependencies'), *flags],
                             cwd=app_dir,
                             capture_output=True)

--- a/pre-commit/tests/test_package_app_dependencies.py
+++ b/pre-commit/tests/test_package_app_dependencies.py
@@ -41,11 +41,12 @@ def app_dir(request):
     return app_dir
 
 
-def test_app_with_pip_dependencies(app_dir):
+@pytest.mark.parametrize("flags",[[],["-d","./Dockerfile.wheels"],["-i","quay.io/pypa/manylinux2014_x86_64"]])
+def test_app_with_pip_dependencies(flags, app_dir):
     app_json = os.path.join(app_dir, 'app.json')
     expected_app_json = os.path.join(app_dir, 'expected_app_json.out')
-
-    result = subprocess.run([os.path.join(PRE_COMMIT_DIR, 'package_app_dependencies')],
+    print(os.path.join(PRE_COMMIT_DIR, 'package_app_dependencies'), *flags)
+    result = subprocess.run([os.path.join(PRE_COMMIT_DIR, 'package_app_dependencies'), *flags],
                             cwd=app_dir,
                             capture_output=True)
     print(result.stderr.decode())


### PR DESCRIPTION
* Ability to pass custom docker images and Dockerfiles to `package_app_dependencies` hook
    * Why?
    During work on Mssccm and Windows Remote Management I came up on some packages that needed external libs to create wheels.

   * How?
    2 new flags can now be added to pre-commit config:
     - `-d ./Dockerfile.example` pass Dockerfile location. Hook will build it, name it after App name and run building wheels inside it
      - `-i python3` pass Docker image tag (this flag is overridden when `-d` is used 

    *  Example
    ```
    repos:
    -   repo: https://github.com/phantomcyber/dev-cicd-tools
         rev: mposluszny/feature-custom-docker-image
         hooks:
         -   id: org-hook
         -   id: package-app-dependencies
               args: ["-d", "./Dockerfile.wheels"]
    -   repo: https://github.com/Yelp/detect-secrets
         rev: v1.4.0
         hooks:
         -   id: detect-secrets
              args: ['--no-verify', '--exclude-files', '^microsoftsccm.json$']
    ```

   * Tests
      Extended pytest test suite by adding tests that covers new flags, together with example Dockerfiles. 
      This feature branch was tested on msccm app with kerberos authentication libs.