### PR TITLE
PAPP-33716 exclude certain Python wheels that are already available in platform

### DIFF
--- a/pre-commit/tests/data/pure-python-py3-app/expected_app_json.out
+++ b/pre-commit/tests/data/pure-python-py3-app/expected_app_json.out
@@ -3,32 +3,8 @@
     "pip_dependencies": {
         "wheel": [
             {
-                "module": "beautifulsoup4",
-                "input_file": "wheels/py3/beautifulsoup4-4.9.1-py3-none-any.whl"
-            },
-            {
                 "module": "dnspython",
                 "input_file": "wheels/shared/dnspython-1.16.0-py2.py3-none-any.whl"
-            },
-            {
-                "module": "soupsieve",
-                "input_file": "wheels/py3/soupsieve-2.3.2.post1-py3-none-any.whl"
-            }
-        ]
-    },
-    "pip39_dependencies": {
-        "wheel": [
-            {
-                "module": "beautifulsoup4",
-                "input_file": "wheels/py3/beautifulsoup4-4.9.1-py3-none-any.whl"
-            },
-            {
-                "module": "dnspython",
-                "input_file": "wheels/shared/dnspython-1.16.0-py2.py3-none-any.whl"
-            },
-            {
-                "module": "soupsieve",
-                "input_file": "wheels/py3/soupsieve-2.5-py3-none-any.whl"
             }
         ]
     }

--- a/pre-commit/tests/data/py3-app/expected_app_json.out
+++ b/pre-commit/tests/data/py3-app/expected_app_json.out
@@ -3,72 +3,16 @@
     "pip_dependencies": {
         "wheel": [
             {
-                "module": "beautifulsoup4",
-                "input_file": "wheels/py3/beautifulsoup4-4.9.1-py3-none-any.whl"
-            },
-            {
-                "module": "certifi",
-                "input_file": "wheels/py3/certifi-2024.2.2-py3-none-any.whl"
-            },
-            {
-                "module": "charset_normalizer",
-                "input_file": "wheels/py3/charset_normalizer-2.0.12-py3-none-any.whl"
-            },
-            {
-                "module": "idna",
-                "input_file": "wheels/py3/idna-3.6-py3-none-any.whl"
-            },
-            {
-                "module": "requests",
-                "input_file": "wheels/shared/requests-2.26.0-py2.py3-none-any.whl"
-            },
-            {
                 "module": "simplejson",
                 "input_file": "wheels/py36/simplejson-3.19.2-cp36-cp36m-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl"
-            },
-            {
-                "module": "soupsieve",
-                "input_file": "wheels/py3/soupsieve-2.3.2.post1-py3-none-any.whl"
-            },
-            {
-                "module": "urllib3",
-                "input_file": "wheels/shared/urllib3-1.26.18-py2.py3-none-any.whl"
             }
         ]
     },
     "pip39_dependencies": {
         "wheel": [
             {
-                "module": "beautifulsoup4",
-                "input_file": "wheels/py3/beautifulsoup4-4.9.1-py3-none-any.whl"
-            },
-            {
-                "module": "certifi",
-                "input_file": "wheels/py3/certifi-2024.2.2-py3-none-any.whl"
-            },
-            {
-                "module": "charset_normalizer",
-                "input_file": "wheels/py3/charset_normalizer-2.0.12-py3-none-any.whl"
-            },
-            {
-                "module": "idna",
-                "input_file": "wheels/py3/idna-3.6-py3-none-any.whl"
-            },
-            {
-                "module": "requests",
-                "input_file": "wheels/shared/requests-2.26.0-py2.py3-none-any.whl"
-            },
-            {
                 "module": "simplejson",
                 "input_file": "wheels/py39/simplejson-3.19.2-cp39-cp39-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl"
-            },
-            {
-                "module": "soupsieve",
-                "input_file": "wheels/py3/soupsieve-2.5-py3-none-any.whl"
-            },
-            {
-                "module": "urllib3",
-                "input_file": "wheels/shared/urllib3-1.26.18-py2.py3-none-any.whl"
             }
         ]
     }


### PR DESCRIPTION
# Summary of change
Update the `package_app_dependencies` pre-commit script, so that it excludes certain direct and transitive dependencies from being packaged:
- beautifulsoup4
  - soupsieve
- parse
- python_dateutil
  - six
- requests
  - certifi
  - charset_normalizer
  - idna
  - urllib3
- sh
- xmltodict

# Reason for change
These packages are already available within the Phantom platform, so apps can use them without bringing their own copies. Many of these (especially requests and beautifulsoup4) are required by almost every app we publish, either as a direct dependency or as a sub-dependency of some other package.

Maintaining redundant copies in all 200+ app repos is a major pain, especially when one of them needs to be updated to resolve a CVE. See the [RFC](https://docs.google.com/document/d/1N2HTjie4Q5bSY-YfeAI4mv4qCXbzyouv8YzkKq1uuZE) for more information.

# Why these packages?
There are _many_ other packages available within the platform, but the platform's `pyproject.toml` [specifically highlights](https://cd.splunkdev.com/phantom/phantom/-/blob/next/alchemy/wheels3/phantom/pyproject.toml?ref_type=heads#L90) these as being used by apps. This list is a good place to start documenting and excluding, as it seems to cover the most commonly-used packages and the ones that are least likely to change in the future. This list could grow as we discover other dependencies that are shared by many apps.

If future efforts (e.g., Odyssey) eventually result in apps running in their own isolated Python environments, this list will also be a good starting point when deciding which packages that base environment should include.

# Changes to docs
Ideally, this change will also come with an enhancement to the public [FAQ](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/FAQ#How_do_I_handle_Python_module_dependencies_for_my_app.3F) for app developers. This document should include a new section, detailing which packages are available, and need not be included by third-party apps. For example:

```markdown
## Use modules provided by the platform
The following Python modules are already available to SOAR apps, so you don't need to specify them as dependencies or include their wheel files:
- beautifulsoup4
- soupsieve
- parse
- python_dateutil
- six
- requests
- certifi
- charset_normalizer
- idna
- urllib3
- sh
- xmltodict
```
