### PR TITLE
Fixing black-flake8 conflict

### DIFF
--- a/lint-configs/tox.ini
+++ b/lint-configs/tox.ini
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 145
 max-complexity = 28
-extend-ignore = F403,E128,E126,E121,E127,E731,E201,E202,F405,E722,D
+extend-ignore = F403,E128,E126,E121,E127,E731,E201,E202,E203,E701,F405,E722,D
 
 [isort]
 line_length = 145


### PR DESCRIPTION
Fixing conflicts between black and flake8 linters.

Based on recommendations from black docs: https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8