### PR TITLE
Migrate to manylinux_2_28_x86_64 image for `package_app_dependencies` hook

### DIFF
--- a/pre-commit/Dockerfile.wheels
+++ b/pre-commit/Dockerfile.wheels
@@ -1,0 +1,1 @@
+FROM quay.io/pypa/manylinux2014_x86_64

--- a/pre-commit/Dockerfile.wheels
+++ b/pre-commit/Dockerfile.wheels
@@ -1,1 +1,0 @@
-FROM quay.io/pypa/manylinux2014_x86_64

--- a/pre-commit/package_app_dependencies
+++ b/pre-commit/package_app_dependencies
@@ -3,8 +3,8 @@
 APP_DIR=$(pwd)
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-IMAGE="quay.io/pypa/manylinux2014_x86_64"
-DOCKERFILE="$SCRIPT_DIR/Dockerfile.wheels"
+IMAGE="quay.io/pypa/manylinux_2_28_x86_64"
+DOCKERFILE=""
 
 while getopts 'i:d:' flag; do
   case "${flag}" in

--- a/pre-commit/package_app_dependencies
+++ b/pre-commit/package_app_dependencies
@@ -4,7 +4,7 @@ APP_DIR=$(pwd)
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 IMAGE="quay.io/pypa/manylinux2014_x86_64"
-DOCKERFILE=""
+DOCKERFILE="$SCRIPT_DIR/Dockerfile.wheels"
 
 while getopts 'i:d:' flag; do
   case "${flag}" in


### PR DESCRIPTION
Due to numerous vulnerabilities found on current wheels build, we are updating manylinux image to newer version, based on alma linux.