### PR TITLE
PAPP-35152: changing documentation to config variables section to be …

### DIFF
--- a/github-actions/start-release/templates/connector_detail.md
+++ b/github-actions/start-release/templates/connector_detail.md
@@ -19,12 +19,12 @@ Minimum Product Version: {{connector.min_phantom_version}}
 {%- if connector.configuration %}
 
 ### Configuration Variables
-This table lists the configuration variables required to operare {{connector.name}}. These variables are specified when configuring a {{connector.product_name}} asset in SOAR.
+This table lists the configuration variables required to operate {{connector.name}}. These variables are specified when configuring a {{connector.product_name}} asset in Splunk SOAR.
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------
 {%- for name, parameters in connector.configuration.items() %}
-{%- if name != "ph" and ("visibility" not in parameters or parameters.visibility|length > 0) %}
+{%- if parameters.data_type != "ph" and ("visibility" not in parameters or parameters.visibility|length > 0) %}
 **{{name}}** | {% if parameters.required == True %} required {% else %} optional {% endif %} | {{ parameters.data_type }} | {{ parameters.description }}
 {%- endif %}
 {%- endfor %}

--- a/github-actions/start-release/templates/connector_detail.md
+++ b/github-actions/start-release/templates/connector_detail.md
@@ -24,7 +24,7 @@ This table lists the configuration variables required to operare {{connector.nam
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------
 {%- for name, parameters in connector.configuration.items() %}
-{%- if name != "ph" %}
+{%- if name != "ph" and ("visibility" not in parameters or parameters.visibility|length > 0) %}
 **{{name}}** | {% if parameters.required == True %} required {% else %} optional {% endif %} | {{ parameters.data_type }} | {{ parameters.description }}
 {%- endif %}
 {%- endfor %}

--- a/github-actions/start-release/templates/connector_detail.md
+++ b/github-actions/start-release/templates/connector_detail.md
@@ -19,7 +19,7 @@ Minimum Product Version: {{connector.min_phantom_version}}
 {%- if connector.configuration %}
 
 ### Configuration Variables
-The below configuration variables are required for this Connector to operate.  These variables are specified when configuring a {{connector.product_name}} asset in SOAR.
+This table lists the configuration variables required to operare {{connector.name}}. These variables are specified when configuring a {{connector.product_name}} asset in SOAR.
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------

--- a/github-actions/start-release/tests/data/build_docs/has_existing_readme/expected_readme.md
+++ b/github-actions/start-release/tests/data/build_docs/has_existing_readme/expected_readme.md
@@ -613,7 +613,7 @@ explanation in Overview, and some individuals Apps have their sections.
 
 
 ### Configuration Variables
-This table lists the configuration variables required to operare QRadar. These variables are specified when configuring a QRadar asset in SOAR.
+This table lists the configuration variables required to operate QRadar. These variables are specified when configuring a QRadar asset in Splunk SOAR.
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------

--- a/github-actions/start-release/tests/data/build_docs/has_existing_readme/expected_readme.md
+++ b/github-actions/start-release/tests/data/build_docs/has_existing_readme/expected_readme.md
@@ -613,7 +613,7 @@ explanation in Overview, and some individuals Apps have their sections.
 
 
 ### Configuration Variables
-The below configuration variables are required for this Connector to operate.  These variables are specified when configuring a QRadar asset in SOAR.
+This table lists the configuration variables required to operare QRadar. These variables are specified when configuring a QRadar asset in SOAR.
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------

--- a/github-actions/start-release/tests/data/build_docs/has_existing_readme_html_and_autogen_md/expected_readme.md
+++ b/github-actions/start-release/tests/data/build_docs/has_existing_readme_html_and_autogen_md/expected_readme.md
@@ -613,7 +613,7 @@ explanation in Overview, and some individuals Apps have their sections.
 
 
 ### Configuration Variables
-This table lists the configuration variables required to operare QRadar. These variables are specified when configuring a QRadar asset in SOAR.
+This table lists the configuration variables required to operate QRadar. These variables are specified when configuring a QRadar asset in Splunk SOAR.
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------

--- a/github-actions/start-release/tests/data/build_docs/has_existing_readme_html_and_autogen_md/expected_readme.md
+++ b/github-actions/start-release/tests/data/build_docs/has_existing_readme_html_and_autogen_md/expected_readme.md
@@ -613,7 +613,7 @@ explanation in Overview, and some individuals Apps have their sections.
 
 
 ### Configuration Variables
-The below configuration variables are required for this Connector to operate.  These variables are specified when configuring a QRadar asset in SOAR.
+This table lists the configuration variables required to operare QRadar. These variables are specified when configuring a QRadar asset in SOAR.
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------

--- a/github-actions/start-release/tests/data/build_docs/has_existing_readme_html_and_md/expected_readme.md
+++ b/github-actions/start-release/tests/data/build_docs/has_existing_readme_html_and_md/expected_readme.md
@@ -613,7 +613,7 @@ explanation in Overview, and some individuals Apps have their sections.
 
 
 ### Configuration Variables
-This table lists the configuration variables required to operare QRadar. These variables are specified when configuring a QRadar asset in SOAR.
+This table lists the configuration variables required to operate QRadar. These variables are specified when configuring a QRadar asset in Splunk SOAR.
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------

--- a/github-actions/start-release/tests/data/build_docs/has_existing_readme_html_and_md/expected_readme.md
+++ b/github-actions/start-release/tests/data/build_docs/has_existing_readme_html_and_md/expected_readme.md
@@ -613,7 +613,7 @@ explanation in Overview, and some individuals Apps have their sections.
 
 
 ### Configuration Variables
-The below configuration variables are required for this Connector to operate.  These variables are specified when configuring a QRadar asset in SOAR.
+This table lists the configuration variables required to operare QRadar. These variables are specified when configuring a QRadar asset in SOAR.
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------

--- a/github-actions/start-release/tests/data/build_docs/has_no_readme/app.json
+++ b/github-actions/start-release/tests/data/build_docs/has_no_readme/app.json
@@ -168,7 +168,8 @@
         "max_events_per_offense": {
             "data_type": "numeric",
             "order": 24,
-            "description": "Maximum accumulated artifacts count per offense (including the default generated offense artifact)"
+            "description": "Maximum accumulated artifacts count per offense (including the default generated offense artifact)",
+            "visibility": []
         }
     },
     "app_config": {

--- a/github-actions/start-release/tests/data/build_docs/has_no_readme/expected_readme.md
+++ b/github-actions/start-release/tests/data/build_docs/has_no_readme/expected_readme.md
@@ -11,7 +11,7 @@ Minimum Product Version: 4.9.39220
 This app supports generic, investigative, and ingestion actions on an IBM QRadar device
 
 ### Configuration Variables
-The below configuration variables are required for this Connector to operate.  These variables are specified when configuring a QRadar asset in SOAR.
+This table lists the configuration variables required to operare QRadar. These variables are specified when configuring a QRadar asset in SOAR.
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------

--- a/github-actions/start-release/tests/data/build_docs/has_no_readme/expected_readme.md
+++ b/github-actions/start-release/tests/data/build_docs/has_no_readme/expected_readme.md
@@ -39,7 +39,6 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **events_ingest_start_time** |  optional  | numeric | Events ingestion initial time (relative to offense start time, default is 60 min)
 **offense_ingest_start_time** |  optional  | numeric | Offense ingestion initial time (relative to offense start time, default is 0 min)
 **event_ingest_end_time** |  optional  | numeric | Events ingestion end time (relative to event ingestion start time, default is 0 min)
-**max_events_per_offense** |  optional  | numeric | Maximum accumulated artifacts count per offense (including the default generated offense artifact)
 
 ### Supported Actions  
 [test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity. This action runs a quick query on the device to check the connection and credentials  

--- a/github-actions/start-release/tests/data/build_docs/has_no_readme/expected_readme.md
+++ b/github-actions/start-release/tests/data/build_docs/has_no_readme/expected_readme.md
@@ -11,7 +11,7 @@ Minimum Product Version: 4.9.39220
 This app supports generic, investigative, and ingestion actions on an IBM QRadar device
 
 ### Configuration Variables
-This table lists the configuration variables required to operare QRadar. These variables are specified when configuring a QRadar asset in SOAR.
+This table lists the configuration variables required to operate QRadar. These variables are specified when configuring a QRadar asset in Splunk SOAR.
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------

--- a/github-actions/start-release/tests/data/build_docs/has_no_readme_set_app_version/expected_readme.md
+++ b/github-actions/start-release/tests/data/build_docs/has_no_readme_set_app_version/expected_readme.md
@@ -11,7 +11,7 @@ Minimum Product Version: 4.9.39220
 This app supports generic, investigative, and ingestion actions on an IBM QRadar device
 
 ### Configuration Variables
-The below configuration variables are required for this Connector to operate.  These variables are specified when configuring a QRadar asset in SOAR.
+This table lists the configuration variables required to operare QRadar. These variables are specified when configuring a QRadar asset in SOAR.
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------

--- a/github-actions/start-release/tests/data/build_docs/has_no_readme_set_app_version/expected_readme.md
+++ b/github-actions/start-release/tests/data/build_docs/has_no_readme_set_app_version/expected_readme.md
@@ -11,7 +11,7 @@ Minimum Product Version: 4.9.39220
 This app supports generic, investigative, and ingestion actions on an IBM QRadar device
 
 ### Configuration Variables
-This table lists the configuration variables required to operare QRadar. These variables are specified when configuring a QRadar asset in SOAR.
+This table lists the configuration variables required to operate QRadar. These variables are specified when configuring a QRadar asset in Splunk SOAR.
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------

--- a/github-actions/start-release/tests/data/readme_to_markdown/has_no_readme/expected_readme.md
+++ b/github-actions/start-release/tests/data/readme_to_markdown/has_no_readme/expected_readme.md
@@ -11,7 +11,7 @@ Minimum Product Version: 4\.9\.39220
 This app supports generic, investigative, and ingestion actions on an IBM QRadar device
 
 ### Configuration Variables
-The below configuration variables are required for this Connector to operate.  These variables are specified when configuring a QRadar asset in SOAR.
+This table lists the configuration variables required to operare QRadar. These variables are specified when configuring a QRadar asset in SOAR.
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------

--- a/github-actions/start-release/tests/data/readme_to_markdown/has_no_readme/expected_readme.md
+++ b/github-actions/start-release/tests/data/readme_to_markdown/has_no_readme/expected_readme.md
@@ -11,7 +11,7 @@ Minimum Product Version: 4\.9\.39220
 This app supports generic, investigative, and ingestion actions on an IBM QRadar device
 
 ### Configuration Variables
-This table lists the configuration variables required to operare QRadar. These variables are specified when configuring a QRadar asset in SOAR.
+This table lists the configuration variables required to operate QRadar. These variables are specified when configuring a QRadar asset in Splunk SOAR.
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------


### PR DESCRIPTION
- Changing the Configuration Variables description after doc reviews for Talos
- Changing so hidden config params don't show up on READme docs