### PR TITLE
fix(ci): Use standalone cache actions

### DIFF
--- a/github-actions/generate-doc/action.yml
+++ b/github-actions/generate-doc/action.yml
@@ -11,7 +11,11 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.9'
-        cache: pip
+    # Reusable actions can't use setup-python's cache because it looks for the running repo's deps
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-soar-ci
     - name: 'Install Dependencies'
       run: |
         pip install --upgrade pip

--- a/github-actions/lint/action.yml
+++ b/github-actions/lint/action.yml
@@ -7,7 +7,11 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.9'
-        cache: pip
+    # Reusable actions can't use setup-python's cache because it looks for the running repo's deps
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-soar-ci
     - name: Install Dependencies
       run: |
           python -m pip install --upgrade pip

--- a/github-actions/resume-release/action.yml
+++ b/github-actions/resume-release/action.yml
@@ -24,7 +24,11 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.9'
-        cache: pip
+    # Reusable actions can't use setup-python's cache because it looks for the running repo's deps
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-soar-ci-release
     - name: 'Install Dependencies'
       shell: bash
       run: |

--- a/github-actions/review-release/action.yml
+++ b/github-actions/review-release/action.yml
@@ -15,7 +15,11 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.9'
-        cache: pip
+    # Reusable actions can't use setup-python's cache because it looks for the running repo's deps
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-soar-ci-release
     - name: 'Install Dependencies'
       shell: bash
       run: |

--- a/github-actions/start-release/action.yml
+++ b/github-actions/start-release/action.yml
@@ -11,7 +11,11 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.9'
-        cache: pip
+    # Reusable actions can't use setup-python's cache because it looks for the running repo's deps
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-soar-ci
     - name: 'Install Dependencies'
       run: |
         pip install --upgrade pip

--- a/github-workflows/.github/workflows/python-package.yml
+++ b/github-workflows/.github/workflows/python-package.yml
@@ -35,7 +35,11 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        cache: pip
+    # Reusable actions can't use setup-python's cache because it looks for the running repo's deps
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-soar-ci
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Reusable actions can't use setup-python's cache because it looks for requirements files in the _executing_ repo. We need to install the requirements from the _defining_ repo, so we need to use the `cache` action manually