### PR TITLE
fix(docs): Render tables and the headings that follow them correctly

### DIFF
--- a/github-actions/start-release/templates/connector_detail.md.j2
+++ b/github-actions/start-release/templates/connector_detail.md.j2
@@ -20,7 +20,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------
 {% for name, parameters in connector.configuration.items() %}
 {% if parameters.data_type != "ph" and ("visibility" not in parameters or parameters.visibility|length > 0) %}
-**{{name}}** | {% if parameters.required == True %} required {% else %} optional {% endif %} | {{ parameters.data_type }} | {{ parameters.description }}
+**{{name}}** | {% if parameters.required == True %} required {% else %} optional {% endif %} | {{ parameters.data_type }} | {{ parameters.description }} |
 {% endif %}
 {% endfor %}
 {% endif %}
@@ -49,7 +49,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
 {% for name, parameters in action.parameters.items() %}
 {% if parameters.data_type != "ph" %}
-**{{name}}** | {% if parameters.required == True %} required {% else %} optional {% endif %} | {{parameters.description}} | {{parameters.data_type}} | {% for contain in parameters.contains %} `{{contain}}` {% endfor %}
+**{{name}}** | {% if parameters.required %} required {% else %} optional {% endif %} | {{parameters.description}} | {{parameters.data_type}} | {% for contain in parameters.contains %} `{{contain}}` {% endfor %} |
 {% endif %}
 {% endfor %}
 {% else %}
@@ -61,7 +61,9 @@ No parameters are required for this action
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
 {% for output in action.output %}
-{{output.data_path}} | {{output.data_type}} | {% for contain in output.contains %} `{{contain}}` {% endfor %} |  {% for example in output.example_values %} {{example}} {% endfor %}
+{% if output %}
+{{output.data_path}} | {{output.data_type}} | {% for contain in output.contains %} `{{contain}}` {% endfor %} |  {% for example in output.example_values %} {{example | trim | replace("\n", " ")}} {% endfor %} |
+{% endif %}
 {% endfor %}
 {% else %}
 No Output

--- a/github-actions/start-release/tests/data/build_docs/has_existing_readme/expected_readme.md
+++ b/github-actions/start-release/tests/data/build_docs/has_existing_readme/expected_readme.md
@@ -543,31 +543,31 @@ This table lists the configuration variables required to operate QRadar. These v
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------
-**device** | required | string | Server IP/Hostname
-**containers_only** | optional | boolean | Ingest only offenses while polling
-**has_offense** | optional | boolean | Fetch only events and flows associated with the offense
-**verify_server_cert** | optional | boolean | Verify server certificate
-**username** | optional | string | Username
-**password** | optional | password | Password
-**authorization_token** | optional | password | Auth Token for QRadar REST API calls
-**timezone** | required | timezone | QRadar timezone
-**add_to_resolved** | optional | boolean | Ingest artifacts into closed/resolved containers
-**artifact_max** | optional | numeric | Maximum event artifacts count per cycle (excluding the default generated offense artifact)
-**ingest_resolved** | optional | boolean | Ingest only open offenses
-**cef_event_map** | optional | string | CEF event map
-**cef_value_map** | optional | string | CEF value map
-**delete_empty_cef_fields** | optional | boolean | Delete the empty CEF fields
-**event_fields_for_query** | optional | string | Event fields to include while querying
-**add_offense_id_to_name** | optional | boolean | Add offense ID to name of containers
-**alternative_ariel_query** | optional | boolean | Alternative ariel query
-**alternative_ingest_algorithm** | optional | boolean | Alternative ingest algorithm for offenses
-**alt_time_field** | optional | string | Alternative ingestion time field
-**alt_initial_ingest_time** | optional | string | Alternative initial ingestion time
-**alt_ingestion_order** | optional | string | Alternative ingestion order for offenses
-**events_ingest_start_time** | optional | numeric | Events ingestion initial time (relative to offense start time, default is 60 min)
-**offense_ingest_start_time** | optional | numeric | Offense ingestion initial time (relative to offense start time, default is 0 min)
-**event_ingest_end_time** | optional | numeric | Events ingestion end time (relative to event ingestion start time, default is 0 min)
-**max_events_per_offense** | optional | numeric | Maximum accumulated artifacts count per offense (including the default generated offense artifact)
+**device** | required | string | Server IP/Hostname |
+**containers_only** | optional | boolean | Ingest only offenses while polling |
+**has_offense** | optional | boolean | Fetch only events and flows associated with the offense |
+**verify_server_cert** | optional | boolean | Verify server certificate |
+**username** | optional | string | Username |
+**password** | optional | password | Password |
+**authorization_token** | optional | password | Auth Token for QRadar REST API calls |
+**timezone** | required | timezone | QRadar timezone |
+**add_to_resolved** | optional | boolean | Ingest artifacts into closed/resolved containers |
+**artifact_max** | optional | numeric | Maximum event artifacts count per cycle (excluding the default generated offense artifact) |
+**ingest_resolved** | optional | boolean | Ingest only open offenses |
+**cef_event_map** | optional | string | CEF event map |
+**cef_value_map** | optional | string | CEF value map |
+**delete_empty_cef_fields** | optional | boolean | Delete the empty CEF fields |
+**event_fields_for_query** | optional | string | Event fields to include while querying |
+**add_offense_id_to_name** | optional | boolean | Add offense ID to name of containers |
+**alternative_ariel_query** | optional | boolean | Alternative ariel query |
+**alternative_ingest_algorithm** | optional | boolean | Alternative ingest algorithm for offenses |
+**alt_time_field** | optional | string | Alternative ingestion time field |
+**alt_initial_ingest_time** | optional | string | Alternative initial ingestion time |
+**alt_ingestion_order** | optional | string | Alternative ingestion order for offenses |
+**events_ingest_start_time** | optional | numeric | Events ingestion initial time (relative to offense start time, default is 60 min) |
+**offense_ingest_start_time** | optional | numeric | Offense ingestion initial time (relative to offense start time, default is 0 min) |
+**event_ingest_end_time** | optional | numeric | Events ingestion end time (relative to event ingestion start time, default is 0 min) |
+**max_events_per_offense** | optional | numeric | Maximum accumulated artifacts count per offense (including the default generated offense artifact) |
 
 ### Supported Actions
 
@@ -615,14 +615,62 @@ The default start_time is the past 5 days. The default end_time is now. The defa
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**start_time** | optional | Start of time range, in epoch time (milliseconds) | numeric | **end_time** | optional | End of time range, in epoch time (milliseconds) | numeric | **count** | optional | Number of offenses to retrieve | numeric | **offense_id** | optional | Comma-separated list of offense IDs to fetch | string | `qradar offense id`
+**start_time** | optional | Start of time range, in epoch time (milliseconds) | numeric | |
+**end_time** | optional | End of time range, in epoch time (milliseconds) | numeric | |
+**count** | optional | Number of offenses to retrieve | numeric | |
+**offense_id** | optional | Comma-separated list of offense IDs to fetch | string | `qradar offense id` |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.count | numeric | | 100 action_result.parameter.end_time | numeric | | 1669900000000 action_result.parameter.offense_id | string | `qradar offense id` | 44 action_result.parameter.start_time | numeric | | 1559900000000 action_result.data.\*.assigned_to | string | | admin action_result.data.\*.categories | string | | License Status action_result.data.\*.category_count | numeric | | 10 action_result.data.\*.close_time | string | | action_result.data.\*.closing_reason_id | string | `qradar offense closing reason id` | action_result.data.\*.closing_user | string | | action_result.data.\*.credibility | numeric | | 4 action_result.data.\*.description | string | | Local Malware Events
-action_result.data.\*.destination_networks | string | | other action_result.data.\*.device_count | numeric | | 3 action_result.data.\*.domain_id | numeric | | action_result.data.\*.event_count | numeric | | 28603163 action_result.data.\*.flow_count | numeric | | 110 action_result.data.\*.follow_up | boolean | | False True action_result.data.\*.id | numeric | `qradar offense id` | 44 action_result.data.\*.inactive | boolean | | False True action_result.data.\*.last_updated_time | numeric | | 1559194600958 action_result.data.\*.local_destination_count | numeric | | 0 action_result.data.\*.magnitude | numeric | | 5 action_result.data.\*.offense_source | string | `ip` | 122.122.122.122 action_result.data.\*.offense_type | numeric | | 0 action_result.data.\*.policy_category_count | numeric | | 0 action_result.data.\*.protected | boolean | | False True action_result.data.\*.relevance | numeric | | 4 action_result.data.\*.remote_destination_count | numeric | | 1 action_result.data.\*.rules.\*.id | numeric | | action_result.data.\*.rules.\*.type | string | | action_result.data.\*.security_category_count | numeric | | 10 action_result.data.\*.severity | numeric | | 6 action_result.data.\*.source_count | numeric | | 1 action_result.data.\*.source_network | string | | Net-10-172-192.Net_10_0_0_0 action_result.data.\*.start_time | numeric | | 1558009780686 action_result.data.\*.status | string | | OPEN action_result.data.\*.username_count | numeric | `user name` | 0 action_result.summary | string | | action_result.summary.total_offenses | numeric | | 1 action_result.message | string | | Fetching all open offenses. Total offenses: 1 Total Offenses: 1 summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'list closing reasons'
+action_result.status | string | | success failed |
+action_result.parameter.count | numeric | | 100 |
+action_result.parameter.end_time | numeric | | 1669900000000 |
+action_result.parameter.offense_id | string | `qradar offense id` | 44 |
+action_result.parameter.start_time | numeric | | 1559900000000 |
+action_result.data.\*.assigned_to | string | | admin |
+action_result.data.\*.categories | string | | License Status |
+action_result.data.\*.category_count | numeric | | 10 |
+action_result.data.\*.close_time | string | | |
+action_result.data.\*.closing_reason_id | string | `qradar offense closing reason id` | |
+action_result.data.\*.closing_user | string | | |
+action_result.data.\*.credibility | numeric | | 4 |
+action_result.data.\*.description | string | | Local Malware Events |
+action_result.data.\*.destination_networks | string | | other |
+action_result.data.\*.device_count | numeric | | 3 |
+action_result.data.\*.domain_id | numeric | | |
+action_result.data.\*.event_count | numeric | | 28603163 |
+action_result.data.\*.flow_count | numeric | | 110 |
+action_result.data.\*.follow_up | boolean | | False True |
+action_result.data.\*.id | numeric | `qradar offense id` | 44 |
+action_result.data.\*.inactive | boolean | | False True |
+action_result.data.\*.last_updated_time | numeric | | 1559194600958 |
+action_result.data.\*.local_destination_count | numeric | | 0 |
+action_result.data.\*.magnitude | numeric | | 5 |
+action_result.data.\*.offense_source | string | `ip` | 122.122.122.122 |
+action_result.data.\*.offense_type | numeric | | 0 |
+action_result.data.\*.policy_category_count | numeric | | 0 |
+action_result.data.\*.protected | boolean | | False True |
+action_result.data.\*.relevance | numeric | | 4 |
+action_result.data.\*.remote_destination_count | numeric | | 1 |
+action_result.data.\*.rules.\*.id | numeric | | |
+action_result.data.\*.rules.\*.type | string | | |
+action_result.data.\*.security_category_count | numeric | | 10 |
+action_result.data.\*.severity | numeric | | 6 |
+action_result.data.\*.source_count | numeric | | 1 |
+action_result.data.\*.source_network | string | | Net-10-172-192.Net_10_0_0_0 |
+action_result.data.\*.start_time | numeric | | 1558009780686 |
+action_result.data.\*.status | string | | OPEN |
+action_result.data.\*.username_count | numeric | `user name` | 0 |
+action_result.summary | string | | |
+action_result.summary.total_offenses | numeric | | 1 |
+action_result.message | string | | Fetching all open offenses. Total offenses: 1 Total Offenses: 1 |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'list closing reasons'
+
 Get a list of offense closing reasons
 
 Type: **investigate** \
@@ -632,13 +680,27 @@ Read only: **True**
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**include_reserved** | optional | Include reserved offense closing reasons | boolean | **include_deleted** | optional | Include deleted offense closing reasons | boolean |
+**include_reserved** | optional | Include reserved offense closing reasons | boolean | |
+**include_deleted** | optional | Include deleted offense closing reasons | boolean | |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.include_deleted | boolean | | True False action_result.parameter.include_reserved | boolean | | True False action_result.data.\*.id | numeric | `qradar offense closing reason id` | 2 action_result.data.\*.is_deleted | boolean | | True False action_result.data.\*.is_reserved | boolean | | True False action_result.data.\*.text | string | | False-Positive, Tuned action_result.summary.total_offense_closing_reasons | numeric | | 5 action_result.message | string | | Total offense closing reasons: 5 summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'get events'
+action_result.status | string | | success failed |
+action_result.parameter.include_deleted | boolean | | True False |
+action_result.parameter.include_reserved | boolean | | True False |
+action_result.data.\*.id | numeric | `qradar offense closing reason id` | 2 |
+action_result.data.\*.is_deleted | boolean | | True False |
+action_result.data.\*.is_reserved | boolean | | True False |
+action_result.data.\*.text | string | | False-Positive, Tuned |
+action_result.summary.total_offense_closing_reasons | numeric | | 5 |
+action_result.message | string | | Total offense closing reasons: 5 |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'get events'
+
 Get events belonging to an offense
 
 Type: **investigate** \
@@ -650,13 +712,72 @@ Use fields_filter parameter to restrict the events returned that match the filte
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**offense_id** | optional | Offense ID to get events of | numeric | `qradar offense id` **start_time** | optional | Start of time range, in epoch time (milliseconds) | numeric | **end_time** | optional | End of time range, in epoch time (milliseconds) | numeric | **count** | optional | Number of events to retrieve | numeric | **fields_filter** | optional | Filter on event field values | string | **interval_days** | optional | Interval days | numeric |
+**offense_id** | optional | Offense ID to get events of | numeric | `qradar offense id` |
+**start_time** | optional | Start of time range, in epoch time (milliseconds) | numeric | |
+**end_time** | optional | End of time range, in epoch time (milliseconds) | numeric | |
+**count** | optional | Number of events to retrieve | numeric | |
+**fields_filter** | optional | Filter on event field values | string | |
+**interval_days** | optional | Interval days | numeric | |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.count | numeric | | 10 action_result.parameter.end_time | numeric | | 1669891174855 action_result.parameter.fields_filter | string | | sourceip='122.122.122.122' action_result.parameter.interval_days | numeric | | 20 action_result.parameter.offense_id | numeric | `qradar offense id` | 44 action_result.parameter.start_time | numeric | | 1559891174855 action_result.data.\*.AccountDomain | string | `domain` `url` | action_result.data.\*.Application | string | | action_result.data.\*.Bytes | string | | action_result.data.\*.BytesReceived | string | | action_result.data.\*.BytesSent | string | | action_result.data.\*.Destination Host Name | string | `host name` | action_result.data.\*.EventID | string | | action_result.data.\*.File Hash | string | | action_result.data.\*.File ID | string | | action_result.data.\*.File Path | string | | action_result.data.\*.Filename | string | | action_result.data.\*.Hostname | string | `host name` | action_result.data.\*.Installer Filename | string | | action_result.data.\*.Message | string | | action_result.data.\*.Payload | string | | Communication with Known Watched Networks There has been event communication with networks that appear on the systems watch and darknet lists. action_result.data.\*.Source Host Name | string | `host name` | action_result.data.\*.categoryname_category | string | | Suspicious Activity action_result.data.\*.destinationaddress | string | `ip` | 122.122.122.122 action_result.data.\*.destinationip | string | `ip` | 122.122.122.122 action_result.data.\*.destinationmac | string | | 00:00:00:00:00:00 action_result.data.\*.destinationport | numeric | `port` | 0 action_result.data.\*.endtime | numeric | | action_result.data.\*.eventcount | numeric | | action_result.data.\*.eventdirection | string | | L2R R2R action_result.data.\*.hostname_logsourceid | string | `host name` | Unknown Host 63 action_result.data.\*.identityip | string | `ip` | action_result.data.\*.logsourcegroupname_logsourceid | string | | Other action_result.data.\*.logsourceid | numeric | | 63 action_result.data.\*.logsourcename_logsourceid | string | | Custom Rule Engine-8 :: qradar action_result.data.\*.protocolname_protocolid | string | | Reserved action_result.data.\*.qid | numeric | | 70750119 action_result.data.\*.qidname_qid | string | | Communication with Known Watched Networks action_result.data.\*.relevance | numeric | | action_result.data.\*.severity | numeric | | action_result.data.\*.sourceaddress | string | `ip` | 122.122.122.122 action_result.data.\*.sourceip | string | `ip` | 122.122.122.122 action_result.data.\*.sourcemac | string | | 00:00:00:00:00:00 action_result.data.\*.sourceport | numeric | `port` | 0 action_result.data.\*.sourcev6 | string | `ipv6` | action_result.data.\*.starttime | numeric | | 1559194870184 action_result.data.\*.username | string | `user name` | action_result.summary.total_events | numeric | | 10 action_result.message | string | | Total events: 10 summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'get flows'
+action_result.status | string | | success failed |
+action_result.parameter.count | numeric | | 10 |
+action_result.parameter.end_time | numeric | | 1669891174855 |
+action_result.parameter.fields_filter | string | | sourceip='122.122.122.122' |
+action_result.parameter.interval_days | numeric | | 20 |
+action_result.parameter.offense_id | numeric | `qradar offense id` | 44 |
+action_result.parameter.start_time | numeric | | 1559891174855 |
+action_result.data.\*.AccountDomain | string | `domain` `url` | |
+action_result.data.\*.Application | string | | |
+action_result.data.\*.Bytes | string | | |
+action_result.data.\*.BytesReceived | string | | |
+action_result.data.\*.BytesSent | string | | |
+action_result.data.\*.Destination Host Name | string | `host name` | |
+action_result.data.\*.EventID | string | | |
+action_result.data.\*.File Hash | string | | |
+action_result.data.\*.File ID | string | | |
+action_result.data.\*.File Path | string | | |
+action_result.data.\*.Filename | string | | |
+action_result.data.\*.Hostname | string | `host name` | |
+action_result.data.\*.Installer Filename | string | | |
+action_result.data.\*.Message | string | | |
+action_result.data.\*.Payload | string | | Communication with Known Watched Networks There has been event communication with networks that appear on the systems watch and darknet lists. |
+action_result.data.\*.Source Host Name | string | `host name` | |
+action_result.data.\*.categoryname_category | string | | Suspicious Activity |
+action_result.data.\*.destinationaddress | string | `ip` | 122.122.122.122 |
+action_result.data.\*.destinationip | string | `ip` | 122.122.122.122 |
+action_result.data.\*.destinationmac | string | | 00:00:00:00:00:00 |
+action_result.data.\*.destinationport | numeric | `port` | 0 |
+action_result.data.\*.endtime | numeric | | |
+action_result.data.\*.eventcount | numeric | | |
+action_result.data.\*.eventdirection | string | | L2R R2R |
+action_result.data.\*.hostname_logsourceid | string | `host name` | Unknown Host 63 |
+action_result.data.\*.identityip | string | `ip` | |
+action_result.data.\*.logsourcegroupname_logsourceid | string | | Other |
+action_result.data.\*.logsourceid | numeric | | 63 |
+action_result.data.\*.logsourcename_logsourceid | string | | Custom Rule Engine-8 :: qradar |
+action_result.data.\*.protocolname_protocolid | string | | Reserved |
+action_result.data.\*.qid | numeric | | 70750119 |
+action_result.data.\*.qidname_qid | string | | Communication with Known Watched Networks |
+action_result.data.\*.relevance | numeric | | |
+action_result.data.\*.severity | numeric | | |
+action_result.data.\*.sourceaddress | string | `ip` | 122.122.122.122 |
+action_result.data.\*.sourceip | string | `ip` | 122.122.122.122 |
+action_result.data.\*.sourcemac | string | | 00:00:00:00:00:00 |
+action_result.data.\*.sourceport | numeric | `port` | 0 |
+action_result.data.\*.sourcev6 | string | `ipv6` | |
+action_result.data.\*.starttime | numeric | | 1559194870184 |
+action_result.data.\*.username | string | `user name` | |
+action_result.summary.total_events | numeric | | 10 |
+action_result.message | string | | Total events: 10 |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'get flows'
+
 Get flows that make up an offense for a particular IP
 
 Type: **investigate** \
@@ -668,13 +789,121 @@ Use the <b>fields_filter</b> parameter to restrict the flows returned. For e.g. 
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**ip** | optional | IP to get all the flows of | string | `ip` **offense_id** | optional | Offense ID to get flows of | numeric | `qradar offense id` **start_time** | optional | Start of time range, in epoch time (milliseconds) | numeric | **end_time** | optional | End of time range, in epoch time (milliseconds) | numeric | **count** | optional | Number of flows to retrieve | numeric | **fields_filter** | optional | Filter in AQL format on flow field values | string |
+**ip** | optional | IP to get all the flows of | string | `ip` |
+**offense_id** | optional | Offense ID to get flows of | numeric | `qradar offense id` |
+**start_time** | optional | Start of time range, in epoch time (milliseconds) | numeric | |
+**end_time** | optional | End of time range, in epoch time (milliseconds) | numeric | |
+**count** | optional | Number of flows to retrieve | numeric | |
+**fields_filter** | optional | Filter in AQL format on flow field values | string | |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.count | numeric | | 100 action_result.parameter.end_time | numeric | | 1559905203000 action_result.parameter.fields_filter | string | | sourceip='127.0.0.1' action_result.parameter.ip | string | `ip` | 122.122.122.122 action_result.parameter.offense_id | numeric | `qradar offense id` | 41 action_result.parameter.start_time | numeric | | 1559905201000 action_result.data.\*.Action | string | | action_result.data.\*.Application Determination Algorithm | numeric | | action_result.data.\*.Content Subject | string | | action_result.data.\*.Content Type | string | | action_result.data.\*.FTP Pass | string | | action_result.data.\*.FTP RETR File | string | | action_result.data.\*.FTP User | string | | action_result.data.\*.File Entropy | string | | action_result.data.\*.File Hash | string | | action_result.data.\*.File Name | string | | action_result.data.\*.File Size | string | | action_result.data.\*.Flow Direction Algorithm | numeric | | action_result.data.\*.Google Search Terms | string | | action_result.data.\*.HTTP Content-Type | string | | action_result.data.\*.HTTP GET Request | string | | action_result.data.\*.HTTP Host | string | | action_result.data.\*.HTTP Referer | string | | action_result.data.\*.HTTP Referrer | string | | action_result.data.\*.HTTP Response Code | string | | action_result.data.\*.HTTP Server | string | | action_result.data.\*.HTTP User Agent | string | | action_result.data.\*.HTTP User-Agent | string | | action_result.data.\*.HTTP Version | string | | action_result.data.\*.Originating User | string | | action_result.data.\*.Password | string | | action_result.data.\*.Request URL | string | | action_result.data.\*.SMTP From | string | | action_result.data.\*.SMTP HELO | string | | action_result.data.\*.SMTP Hello | string | | action_result.data.\*.SMTP To | string | | action_result.data.\*.Search Arguments | string | | action_result.data.\*.VLAN Tag | string | | action_result.data.\*.applicationid | numeric | | 1011 action_result.data.\*.applicationname_applicationid | string | | action_result.data.\*.category | numeric | | 18448 action_result.data.\*.categoryname_category | string | | action_result.data.\*.credibility | numeric | | 10 action_result.data.\*.destinationasn | string | | action_result.data.\*.destinationbytes | numeric | | 11567 action_result.data.\*.destinationdscp | numeric | | action_result.data.\*.destinationflags | string | | action_result.data.\*.destinationifindex | string | | action_result.data.\*.destinationip | string | `ip` | 10.1.16.15 action_result.data.\*.destinationpackets | numeric | | 108 action_result.data.\*.destinationpayload | string | | action_result.data.\*.destinationport | numeric | `port` | 3365 action_result.data.\*.destinationprecedence | numeric | | action_result.data.\*.destinationv6 | string | | 0:0:0:0:0:0:0:0 action_result.data.\*.domainid | numeric | | action_result.data.\*.firstpackettime | numeric | | 1559905202000 action_result.data.\*.flowbias | string | | action_result.data.\*.flowdirection | string | | L2R action_result.data.\*.flowid | numeric | | action_result.data.\*.flowinterface | string | | action_result.data.\*.flowinterfaceid | string | | 5 action_result.data.\*.flowsource | string | | action_result.data.\*.flowtype | numeric | | action_result.data.\*.fullmatchlist | string | | action_result.data.\*.geographic | string | | NorthAmerica.UnitedStates action_result.data.\*.hasdestinationpayload | boolean | | action_result.data.\*.hasoffense | boolean | | True action_result.data.\*.hassourcepayload | boolean | | False action_result.data.\*.hastlv | boolean | | action_result.data.\*.icmpcode | string | | action_result.data.\*.icmptype | string | | action_result.data.\*.intervalid | numeric | | 1603463820 action_result.data.\*.isduplicate | boolean | | action_result.data.\*.lastpackettime | numeric | | 1559905202999 action_result.data.\*.partialmatchlist | string | | action_result.data.\*.processorid | numeric | | 8 action_result.data.\*.protocolid | numeric | | action_result.data.\*.protocolname_protocolid | string | | action_result.data.\*.qid | numeric | | 53250087 action_result.data.\*.qidname_qid | string | | Test.Securetest action_result.data.\*.relevance | numeric | | action_result.data.\*.retentionbucket | string | | action_result.data.\*.severity | numeric | | 1 action_result.data.\*.sourceasn | string | | action_result.data.\*.sourcebytes | numeric | | 1031681 action_result.data.\*.sourcedscp | numeric | | action_result.data.\*.sourceflags | string | | action_result.data.\*.sourceifindex | string | | action_result.data.\*.sourceip | string | `ip` | 127.0.0.1 action_result.data.\*.sourcepackets | numeric | | 783 action_result.data.\*.sourcepayload | string | | action_result.data.\*.sourceport | numeric | | 4806 action_result.data.\*.sourceprecedence | numeric | | action_result.data.\*.sourcev6 | string | `ipv6` | 0:0:0:0:0:0:0:0 action_result.data.\*.starttime | numeric | | 1559905201000 action_result.data.\*.viewobjectpair | string | | action_result.summary.total_flows | numeric | | 33 action_result.message | string | | Total flows: 33 summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'offense details'
+action_result.status | string | | success failed |
+action_result.parameter.count | numeric | | 100 |
+action_result.parameter.end_time | numeric | | 1559905203000 |
+action_result.parameter.fields_filter | string | | sourceip='127.0.0.1' |
+action_result.parameter.ip | string | `ip` | 122.122.122.122 |
+action_result.parameter.offense_id | numeric | `qradar offense id` | 41 |
+action_result.parameter.start_time | numeric | | 1559905201000 |
+action_result.data.\*.Action | string | | |
+action_result.data.\*.Application Determination Algorithm | numeric | | |
+action_result.data.\*.Content Subject | string | | |
+action_result.data.\*.Content Type | string | | |
+action_result.data.\*.FTP Pass | string | | |
+action_result.data.\*.FTP RETR File | string | | |
+action_result.data.\*.FTP User | string | | |
+action_result.data.\*.File Entropy | string | | |
+action_result.data.\*.File Hash | string | | |
+action_result.data.\*.File Name | string | | |
+action_result.data.\*.File Size | string | | |
+action_result.data.\*.Flow Direction Algorithm | numeric | | |
+action_result.data.\*.Google Search Terms | string | | |
+action_result.data.\*.HTTP Content-Type | string | | |
+action_result.data.\*.HTTP GET Request | string | | |
+action_result.data.\*.HTTP Host | string | | |
+action_result.data.\*.HTTP Referer | string | | |
+action_result.data.\*.HTTP Referrer | string | | |
+action_result.data.\*.HTTP Response Code | string | | |
+action_result.data.\*.HTTP Server | string | | |
+action_result.data.\*.HTTP User Agent | string | | |
+action_result.data.\*.HTTP User-Agent | string | | |
+action_result.data.\*.HTTP Version | string | | |
+action_result.data.\*.Originating User | string | | |
+action_result.data.\*.Password | string | | |
+action_result.data.\*.Request URL | string | | |
+action_result.data.\*.SMTP From | string | | |
+action_result.data.\*.SMTP HELO | string | | |
+action_result.data.\*.SMTP Hello | string | | |
+action_result.data.\*.SMTP To | string | | |
+action_result.data.\*.Search Arguments | string | | |
+action_result.data.\*.VLAN Tag | string | | |
+action_result.data.\*.applicationid | numeric | | 1011 |
+action_result.data.\*.applicationname_applicationid | string | | |
+action_result.data.\*.category | numeric | | 18448 |
+action_result.data.\*.categoryname_category | string | | |
+action_result.data.\*.credibility | numeric | | 10 |
+action_result.data.\*.destinationasn | string | | |
+action_result.data.\*.destinationbytes | numeric | | 11567 |
+action_result.data.\*.destinationdscp | numeric | | |
+action_result.data.\*.destinationflags | string | | |
+action_result.data.\*.destinationifindex | string | | |
+action_result.data.\*.destinationip | string | `ip` | 10.1.16.15 |
+action_result.data.\*.destinationpackets | numeric | | 108 |
+action_result.data.\*.destinationpayload | string | | |
+action_result.data.\*.destinationport | numeric | `port` | 3365 |
+action_result.data.\*.destinationprecedence | numeric | | |
+action_result.data.\*.destinationv6 | string | | 0:0:0:0:0:0:0:0 |
+action_result.data.\*.domainid | numeric | | |
+action_result.data.\*.firstpackettime | numeric | | 1559905202000 |
+action_result.data.\*.flowbias | string | | |
+action_result.data.\*.flowdirection | string | | L2R |
+action_result.data.\*.flowid | numeric | | |
+action_result.data.\*.flowinterface | string | | |
+action_result.data.\*.flowinterfaceid | string | | 5 |
+action_result.data.\*.flowsource | string | | |
+action_result.data.\*.flowtype | numeric | | |
+action_result.data.\*.fullmatchlist | string | | |
+action_result.data.\*.geographic | string | | NorthAmerica.UnitedStates |
+action_result.data.\*.hasdestinationpayload | boolean | | |
+action_result.data.\*.hasoffense | boolean | | True |
+action_result.data.\*.hassourcepayload | boolean | | False |
+action_result.data.\*.hastlv | boolean | | |
+action_result.data.\*.icmpcode | string | | |
+action_result.data.\*.icmptype | string | | |
+action_result.data.\*.intervalid | numeric | | 1603463820 |
+action_result.data.\*.isduplicate | boolean | | |
+action_result.data.\*.lastpackettime | numeric | | 1559905202999 |
+action_result.data.\*.partialmatchlist | string | | |
+action_result.data.\*.processorid | numeric | | 8 |
+action_result.data.\*.protocolid | numeric | | |
+action_result.data.\*.protocolname_protocolid | string | | |
+action_result.data.\*.qid | numeric | | 53250087 |
+action_result.data.\*.qidname_qid | string | | Test.Securetest |
+action_result.data.\*.relevance | numeric | | |
+action_result.data.\*.retentionbucket | string | | |
+action_result.data.\*.severity | numeric | | 1 |
+action_result.data.\*.sourceasn | string | | |
+action_result.data.\*.sourcebytes | numeric | | 1031681 |
+action_result.data.\*.sourcedscp | numeric | | |
+action_result.data.\*.sourceflags | string | | |
+action_result.data.\*.sourceifindex | string | | |
+action_result.data.\*.sourceip | string | `ip` | 127.0.0.1 |
+action_result.data.\*.sourcepackets | numeric | | 783 |
+action_result.data.\*.sourcepayload | string | | |
+action_result.data.\*.sourceport | numeric | | 4806 |
+action_result.data.\*.sourceprecedence | numeric | | |
+action_result.data.\*.sourcev6 | string | `ipv6` | 0:0:0:0:0:0:0:0 |
+action_result.data.\*.starttime | numeric | | 1559905201000 |
+action_result.data.\*.viewobjectpair | string | | |
+action_result.summary.total_flows | numeric | | 33 |
+action_result.message | string | | Total flows: 33 |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'offense details'
+
 Get details about an offense
 
 Type: **investigate** \
@@ -686,16 +915,65 @@ If the <b>ingest_offense</b> parameter is checked, then, it will ingest the even
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**offense_id** | required | Offense ID to get the details of | numeric | `qradar offense id` **tenant_id** | optional | Tenant ID for saving container | numeric | **ingest_offense** | optional | Ingest offense into Phantom | boolean |
+**offense_id** | required | Offense ID to get the details of | numeric | `qradar offense id` |
+**tenant_id** | optional | Tenant ID for saving container | numeric | |
+**ingest_offense** | optional | Ingest offense into Phantom | boolean | |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.ingest_offense | boolean | | True False action_result.parameter.offense_id | numeric | `qradar offense id` | 43 action_result.parameter.tenant_id | numeric | | 123 action_result.data.\*.assigned_to | string | | admin action_result.data.\*.categories | string | | Error action_result.data.\*.category_count | numeric | | 4 action_result.data.\*.close_time | string | | 1602888300000 action_result.data.\*.closing_reason_id | string | `qradar offense closing reason id` | 3 action_result.data.\*.closing_user | string | | root action_result.data.\*.credibility | numeric | | 4 action_result.data.\*.description | string | | Anomaly: Access to Test or Test Defined Address
-preceded by Communication with Known Watched Networks
-action_result.data.\*.destination_networks | string | | other action_result.data.\*.device_count | numeric | | 3 action_result.data.\*.domain_id | numeric | | action_result.data.\*.event_count | numeric | | 1035 action_result.data.\*.flow_count | numeric | | 0 action_result.data.\*.follow_up | boolean | | False True action_result.data.\*.id | numeric | `qradar offense id` | 43 action_result.data.\*.inactive | boolean | | False True action_result.data.\*.last_updated_time | numeric | | 1559125383270 action_result.data.\*.local_destination_count | numeric | | 0 action_result.data.\*.magnitude | numeric | | 4 action_result.data.\*.offense_source | string | `ip` | 122.122.122.122 action_result.data.\*.offense_type | numeric | | 0 action_result.data.\*.policy_category_count | numeric | | 0 action_result.data.\*.protected | boolean | | False True action_result.data.\*.relevance | numeric | | 2 action_result.data.\*.remote_destination_count | numeric | | 1 action_result.data.\*.rules.\*.id | numeric | | action_result.data.\*.rules.\*.type | string | | action_result.data.\*.security_category_count | numeric | | 4 action_result.data.\*.severity | numeric | | 7 action_result.data.\*.source_count | numeric | | 1 action_result.data.\*.source_network | string | | other action_result.data.\*.start_time | numeric | | 1558008289506 action_result.data.\*.status | string | | OPEN action_result.data.\*.username_count | numeric | `user name` | 0 action_result.summary.flow_count | numeric | | 0 action_result.summary.name | string | | Anomaly: Access to Test or Test Defined Address
-preceded by Communication with Known Watched Networks action_result.summary.source | string | `ip` | 122.122.122.122 action_result.summary.start_time | string | | 2019-04-04 21:28:47 UTC action_result.summary.status | string | | OPEN action_result.summary.total_offenses | numeric | | 1 action_result.summary.update_time | string | | 2019-05-14 10:23:03 UTC action_result.message | string | | Total offenses: 1 summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'alt manage ingestion'
+action_result.status | string | | success failed |
+action_result.parameter.ingest_offense | boolean | | True False |
+action_result.parameter.offense_id | numeric | `qradar offense id` | 43 |
+action_result.parameter.tenant_id | numeric | | 123 |
+action_result.data.\*.assigned_to | string | | admin |
+action_result.data.\*.categories | string | | Error |
+action_result.data.\*.category_count | numeric | | 4 |
+action_result.data.\*.close_time | string | | 1602888300000 |
+action_result.data.\*.closing_reason_id | string | `qradar offense closing reason id` | 3 |
+action_result.data.\*.closing_user | string | | root |
+action_result.data.\*.credibility | numeric | | 4 |
+action_result.data.\*.description | string | | Anomaly: Access to Test or Test Defined Address preceded by Communication with Known Watched Networks |
+action_result.data.\*.destination_networks | string | | other |
+action_result.data.\*.device_count | numeric | | 3 |
+action_result.data.\*.domain_id | numeric | | |
+action_result.data.\*.event_count | numeric | | 1035 |
+action_result.data.\*.flow_count | numeric | | 0 |
+action_result.data.\*.follow_up | boolean | | False True |
+action_result.data.\*.id | numeric | `qradar offense id` | 43 |
+action_result.data.\*.inactive | boolean | | False True |
+action_result.data.\*.last_updated_time | numeric | | 1559125383270 |
+action_result.data.\*.local_destination_count | numeric | | 0 |
+action_result.data.\*.magnitude | numeric | | 4 |
+action_result.data.\*.offense_source | string | `ip` | 122.122.122.122 |
+action_result.data.\*.offense_type | numeric | | 0 |
+action_result.data.\*.policy_category_count | numeric | | 0 |
+action_result.data.\*.protected | boolean | | False True |
+action_result.data.\*.relevance | numeric | | 2 |
+action_result.data.\*.remote_destination_count | numeric | | 1 |
+action_result.data.\*.rules.\*.id | numeric | | |
+action_result.data.\*.rules.\*.type | string | | |
+action_result.data.\*.security_category_count | numeric | | 4 |
+action_result.data.\*.severity | numeric | | 7 |
+action_result.data.\*.source_count | numeric | | 1 |
+action_result.data.\*.source_network | string | | other |
+action_result.data.\*.start_time | numeric | | 1558008289506 |
+action_result.data.\*.status | string | | OPEN |
+action_result.data.\*.username_count | numeric | `user name` | 0 |
+action_result.summary.flow_count | numeric | | 0 |
+action_result.summary.name | string | | Anomaly: Access to Test or Test Defined Address preceded by Communication with Known Watched Networks |
+action_result.summary.source | string | `ip` | 122.122.122.122 |
+action_result.summary.start_time | string | | 2019-04-04 21:28:47 UTC |
+action_result.summary.status | string | | OPEN |
+action_result.summary.total_offenses | numeric | | 1 |
+action_result.summary.update_time | string | | 2019-05-14 10:23:03 UTC |
+action_result.message | string | | Total offenses: 1 |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'alt manage ingestion'
+
 Manage ingestion details
 
 Type: **generic** \
@@ -707,13 +985,45 @@ The general structure of the state file is {"app_version":"app_version", "last_s
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**operation** | required | Operation to perform on the ingestion data stored in the state file | string | **datetime** | optional | Datetime string to be stored against the ingestion data in the state file | string | **offense_id** | optional | Offense ID against which to store the 'datetime' parameter value | string | `qradar offense id`
+**operation** | required | Operation to perform on the ingestion data stored in the state file | string | |
+**datetime** | optional | Datetime string to be stored against the ingestion data in the state file | string | |
+**offense_id** | optional | Offense ID against which to store the 'datetime' parameter value | string | `qradar offense id` |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.datetime | string | | 2019-12-09 11:11:11.0001 action_result.parameter.offense_id | numeric | `qradar offense id` | 4 action_result.parameter.operation | string | | get last saved ingestion time data action_result.data.\*.last_ingested_events_ingest_time | string | | Offense ID_1=Fri Nov 29 10:05:25 2019 UTC +0000, Offense ID_3=Fri Nov 29 10:01:24 2019 UTC +0000, Offense ID_2=Fri Nov 29 10:03:18 2019 UTC +0000 action_result.data.\*.last_ingested_events_ingest_time_as_epoch.1 | numeric | | 1575021925702 action_result.data.\*.last_ingested_events_ingest_time_as_epoch.10 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.19 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.20 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.21 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.22 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.23 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.24 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.74 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.75 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.76 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.77 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.78 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.79 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.80 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.82 | numeric | | action_result.data.\*.last_saved_offense_ingest_time | string | | Mon Dec 09 11:11:11 2019 UTC +0000 action_result.data.\*.last_saved_offense_ingest_time_as_epoch | numeric | | 1575889871000 action_result.summary.last_ingested_events_ingest_time | string | | Offense ID_1=Fri Nov 29 10:05:25 2019 UTC +0000, Offense ID_3=Fri Nov 29 10:01:24 2019 UTC +0000, Offense ID_2=Fri Nov 29 10:03:18 2019 UTC +0000 action_result.summary.last_saved_offense_ingest_time | string | | Mon Dec 09 11:11:11 2019 UTC +0000 action_result.message | string | | Last saved offense ingest time: Mon Dec 09 11:11:11 2019 UTC +0000, Last ingested events ingest time: Offense ID_1=Fri Nov 29 10:05:25 2019 UTC +0000, Offense ID_3=Fri Nov 29 10:01:24 2019 UTC +0000, Offense ID_2=Fri Nov 29 10:03:18 2019 UTC +0000 summary.total_objects | numeric | | 2 summary.total_objects_successful | numeric | | 2 ## action: 'run query'
+action_result.status | string | | success failed |
+action_result.parameter.datetime | string | | 2019-12-09 11:11:11.0001 |
+action_result.parameter.offense_id | numeric | `qradar offense id` | 4 |
+action_result.parameter.operation | string | | get last saved ingestion time data |
+action_result.data.\*.last_ingested_events_ingest_time | string | | Offense ID_1=Fri Nov 29 10:05:25 2019 UTC +0000, Offense ID_3=Fri Nov 29 10:01:24 2019 UTC +0000, Offense ID_2=Fri Nov 29 10:03:18 2019 UTC +0000 |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.1 | numeric | | 1575021925702 |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.10 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.19 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.20 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.21 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.22 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.23 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.24 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.74 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.75 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.76 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.77 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.78 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.79 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.80 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.82 | numeric | | |
+action_result.data.\*.last_saved_offense_ingest_time | string | | Mon Dec 09 11:11:11 2019 UTC +0000 |
+action_result.data.\*.last_saved_offense_ingest_time_as_epoch | numeric | | 1575889871000 |
+action_result.summary.last_ingested_events_ingest_time | string | | Offense ID_1=Fri Nov 29 10:05:25 2019 UTC +0000, Offense ID_3=Fri Nov 29 10:01:24 2019 UTC +0000, Offense ID_2=Fri Nov 29 10:03:18 2019 UTC +0000 |
+action_result.summary.last_saved_offense_ingest_time | string | | Mon Dec 09 11:11:11 2019 UTC +0000 |
+action_result.message | string | | Last saved offense ingest time: Mon Dec 09 11:11:11 2019 UTC +0000, Last ingested events ingest time: Offense ID_1=Fri Nov 29 10:05:25 2019 UTC +0000, Offense ID_3=Fri Nov 29 10:01:24 2019 UTC +0000, Offense ID_2=Fri Nov 29 10:03:18 2019 UTC +0000 |
+summary.total_objects | numeric | | 2 |
+summary.total_objects_successful | numeric | | 2 |
+
+## action: 'run query'
+
 Execute an ariel query on the QRadar device
 
 Type: **investigate** \
@@ -725,13 +1035,78 @@ Use this action to execute queries using AQL on the QRadar device. AQL is a well
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**query** | required | Ariel Query | string | `qradar ariel query`
+**query** | required | Ariel Query | string | `qradar ariel query` |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.query | string | `qradar ariel query` | select qid from events action_result.data.\*.events.\*.AccountDomain | string | | action_result.data.\*.events.\*.Application | string | | action_result.data.\*.events.\*.Bytes | string | | action_result.data.\*.events.\*.BytesReceived | string | | action_result.data.\*.events.\*.BytesSent | string | | action_result.data.\*.events.\*.Destination Host Name | string | | action_result.data.\*.events.\*.EventID | string | | action_result.data.\*.events.\*.File Hash | string | | action_result.data.\*.events.\*.File ID | string | | action_result.data.\*.events.\*.File Path | string | | action_result.data.\*.events.\*.Filename | string | | action_result.data.\*.events.\*.Installer Filename | string | | action_result.data.\*.events.\*.Message | string | | action_result.data.\*.events.\*.Payload | string | | action_result.data.\*.events.\*.Source Host Name | string | | action_result.data.\*.events.\*.category | numeric | | 38750003 action_result.data.\*.events.\*.categoryname_category | string | | action_result.data.\*.events.\*.destinationaddress | string | | action_result.data.\*.events.\*.destinationip | string | `ip` | 122.122.122.122 action_result.data.\*.events.\*.destinationmac | string | | action_result.data.\*.events.\*.destinationport | numeric | | 0 action_result.data.\*.events.\*.endtime | numeric | | action_result.data.\*.events.\*.eventcount | numeric | | 1 action_result.data.\*.events.\*.eventdirection | string | | action_result.data.\*.events.\*.hostname_logsourceid | string | | action_result.data.\*.events.\*.identityip | string | `ip` | 122.122.122.122 action_result.data.\*.events.\*.logsourcegroupname_logsourceid | string | | action_result.data.\*.events.\*.logsourceid | numeric | | 65 action_result.data.\*.events.\*.logsourcename_logsourceid | string | | action_result.data.\*.events.\*.magnitude | numeric | | 5 action_result.data.\*.events.\*.protocolid | numeric | | 255 action_result.data.\*.events.\*.protocolname_protocolid | string | | action_result.data.\*.events.\*.qid | numeric | | 38750003 action_result.data.\*.events.\*.qidname_qid | string | | action_result.data.\*.events.\*.queid | numeric | | action_result.data.\*.events.\*.relevance | numeric | | action_result.data.\*.events.\*.severity | numeric | | action_result.data.\*.events.\*.sourceaddress | string | | action_result.data.\*.events.\*.sourceip | string | `ip` | 122.122.122.122 action_result.data.\*.events.\*.sourcemac | string | | action_result.data.\*.events.\*.sourceport | numeric | | 0 action_result.data.\*.events.\*.starttime | numeric | | 1559907060001 action_result.data.\*.events.\*.username | string | `user name` | action_result.data.\*.flows.\*.category | numeric | | action_result.data.\*.flows.\*.destinationbytes | numeric | | action_result.data.\*.flows.\*.destinationflags | string | | action_result.data.\*.flows.\*.destinationip | string | | action_result.data.\*.flows.\*.destinationpackets | numeric | | action_result.data.\*.flows.\*.firstpackettime | numeric | | action_result.data.\*.flows.\*.flowtype | numeric | | action_result.data.\*.flows.\*.lastpackettime | numeric | | action_result.data.\*.flows.\*.protocolid | numeric | | action_result.data.\*.flows.\*.qid | numeric | | action_result.data.\*.flows.\*.sourcebytes | numeric | | action_result.data.\*.flows.\*.sourceflags | string | | action_result.data.\*.flows.\*.sourceip | string | | action_result.data.\*.flows.\*.sourcepackets | numeric | | action_result.summary | string | | action_result.message | string | | Successfully ran query summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'add listitem'
+action_result.status | string | | success failed |
+action_result.parameter.query | string | `qradar ariel query` | select qid from events |
+action_result.data.\*.events.\*.AccountDomain | string | | |
+action_result.data.\*.events.\*.Application | string | | |
+action_result.data.\*.events.\*.Bytes | string | | |
+action_result.data.\*.events.\*.BytesReceived | string | | |
+action_result.data.\*.events.\*.BytesSent | string | | |
+action_result.data.\*.events.\*.Destination Host Name | string | | |
+action_result.data.\*.events.\*.EventID | string | | |
+action_result.data.\*.events.\*.File Hash | string | | |
+action_result.data.\*.events.\*.File ID | string | | |
+action_result.data.\*.events.\*.File Path | string | | |
+action_result.data.\*.events.\*.Filename | string | | |
+action_result.data.\*.events.\*.Installer Filename | string | | |
+action_result.data.\*.events.\*.Message | string | | |
+action_result.data.\*.events.\*.Payload | string | | |
+action_result.data.\*.events.\*.Source Host Name | string | | |
+action_result.data.\*.events.\*.category | numeric | | 38750003 |
+action_result.data.\*.events.\*.categoryname_category | string | | |
+action_result.data.\*.events.\*.destinationaddress | string | | |
+action_result.data.\*.events.\*.destinationip | string | `ip` | 122.122.122.122 |
+action_result.data.\*.events.\*.destinationmac | string | | |
+action_result.data.\*.events.\*.destinationport | numeric | | 0 |
+action_result.data.\*.events.\*.endtime | numeric | | |
+action_result.data.\*.events.\*.eventcount | numeric | | 1 |
+action_result.data.\*.events.\*.eventdirection | string | | |
+action_result.data.\*.events.\*.hostname_logsourceid | string | | |
+action_result.data.\*.events.\*.identityip | string | `ip` | 122.122.122.122 |
+action_result.data.\*.events.\*.logsourcegroupname_logsourceid | string | | |
+action_result.data.\*.events.\*.logsourceid | numeric | | 65 |
+action_result.data.\*.events.\*.logsourcename_logsourceid | string | | |
+action_result.data.\*.events.\*.magnitude | numeric | | 5 |
+action_result.data.\*.events.\*.protocolid | numeric | | 255 |
+action_result.data.\*.events.\*.protocolname_protocolid | string | | |
+action_result.data.\*.events.\*.qid | numeric | | 38750003 |
+action_result.data.\*.events.\*.qidname_qid | string | | |
+action_result.data.\*.events.\*.queid | numeric | | |
+action_result.data.\*.events.\*.relevance | numeric | | |
+action_result.data.\*.events.\*.severity | numeric | | |
+action_result.data.\*.events.\*.sourceaddress | string | | |
+action_result.data.\*.events.\*.sourceip | string | `ip` | 122.122.122.122 |
+action_result.data.\*.events.\*.sourcemac | string | | |
+action_result.data.\*.events.\*.sourceport | numeric | | 0 |
+action_result.data.\*.events.\*.starttime | numeric | | 1559907060001 |
+action_result.data.\*.events.\*.username | string | `user name` | |
+action_result.data.\*.flows.\*.category | numeric | | |
+action_result.data.\*.flows.\*.destinationbytes | numeric | | |
+action_result.data.\*.flows.\*.destinationflags | string | | |
+action_result.data.\*.flows.\*.destinationip | string | | |
+action_result.data.\*.flows.\*.destinationpackets | numeric | | |
+action_result.data.\*.flows.\*.firstpackettime | numeric | | |
+action_result.data.\*.flows.\*.flowtype | numeric | | |
+action_result.data.\*.flows.\*.lastpackettime | numeric | | |
+action_result.data.\*.flows.\*.protocolid | numeric | | |
+action_result.data.\*.flows.\*.qid | numeric | | |
+action_result.data.\*.flows.\*.sourcebytes | numeric | | |
+action_result.data.\*.flows.\*.sourceflags | string | | |
+action_result.data.\*.flows.\*.sourceip | string | | |
+action_result.data.\*.flows.\*.sourcepackets | numeric | | |
+action_result.summary | string | | |
+action_result.message | string | | Successfully ran query |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'add listitem'
+
 Add an item to a reference set in QRadar
 
 Type: **generic** \
@@ -741,13 +1116,30 @@ Read only: **False**
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**reference_set_name** | required | Name of reference set to add to | string | **reference_set_value** | required | Value to add to the reference set | string |
+**reference_set_name** | required | Name of reference set to add to | string | |
+**reference_set_value** | required | Value to add to the reference set | string | |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.reference_set_name | string | | Demo action_result.parameter.reference_set_value | string | | 122.122.122.122 action_result.data.\*.creation_time | numeric | | 1558518483009 action_result.data.\*.element_type | string | | IP action_result.data.\*.name | string | | Demo action_result.data.\*.number_of_elements | numeric | | 3 action_result.data.\*.timeout_type | string | | FIRST_SEEN action_result.summary.element_type | string | | IP action_result.summary.name | string | | Demo action_result.summary.number_of_elements | numeric | | 3 action_result.message | string | | Element type: IP, Name: Demo, Number of elements: 3 summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'close offense'
+action_result.status | string | | success failed |
+action_result.parameter.reference_set_name | string | | Demo |
+action_result.parameter.reference_set_value | string | | 122.122.122.122 |
+action_result.data.\*.creation_time | numeric | | 1558518483009 |
+action_result.data.\*.element_type | string | | IP |
+action_result.data.\*.name | string | | Demo |
+action_result.data.\*.number_of_elements | numeric | | 3 |
+action_result.data.\*.timeout_type | string | | FIRST_SEEN |
+action_result.summary.element_type | string | | IP |
+action_result.summary.name | string | | Demo |
+action_result.summary.number_of_elements | numeric | | 3 |
+action_result.message | string | | Element type: IP, Name: Demo, Number of elements: 3 |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'close offense'
+
 Close an active offense, marking status=CLOSED
 
 Type: **generic** \
@@ -757,17 +1149,62 @@ Read only: **False**
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**offense_id** | required | Offense ID to close | numeric | `qradar offense id` **closing_reason_id** | required | Reason for closing offense | numeric | `qradar offense closing reason id`
+**offense_id** | required | Offense ID to close | numeric | `qradar offense id` |
+**closing_reason_id** | required | Reason for closing offense | numeric | `qradar offense closing reason id` |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.closing_reason_id | numeric | `qradar offense closing reason id` | 1 action_result.parameter.offense_id | numeric | `qradar offense id` | 41 action_result.data.\*.assigned_to | string | | admin action_result.data.\*.categories | string | | Error action_result.data.\*.category_count | numeric | | 4 action_result.data.\*.close_time | numeric | | 1559905203000 action_result.data.\*.closing_reason_id | numeric | `qradar offense closing reason id` | 1 action_result.data.\*.closing_user | string | | API_token: Phantom action_result.data.\*.credibility | numeric | | 4 action_result.data.\*.description | string | | Anomaly: Access to Test or Test Defined Address
-preceded by Communication with Known Watched Networks
-action_result.data.\*.destination_networks | string | | other action_result.data.\*.device_count | numeric | | 3 action_result.data.\*.domain_id | numeric | | action_result.data.\*.event_count | numeric | | 2660 action_result.data.\*.flow_count | numeric | | 0 action_result.data.\*.follow_up | boolean | | False True action_result.data.\*.id | numeric | `qradar offense id` | 41 action_result.data.\*.inactive | boolean | | False True action_result.data.\*.last_updated_time | numeric | | 1557829383413 action_result.data.\*.local_destination_count | numeric | | 0 action_result.data.\*.magnitude | numeric | | 3 action_result.data.\*.offense_source | string | `ip` | 122.122.122.122 action_result.data.\*.offense_type | numeric | | 0 action_result.data.\*.policy_category_count | numeric | | 0 action_result.data.\*.protected | boolean | | False True action_result.data.\*.relevance | numeric | | 2 action_result.data.\*.remote_destination_count | numeric | | 1 action_result.data.\*.rules.\*.id | numeric | | action_result.data.\*.rules.\*.type | string | | action_result.data.\*.security_category_count | numeric | | 4 action_result.data.\*.severity | numeric | | 7 action_result.data.\*.source_count | numeric | | 1 action_result.data.\*.source_network | string | | other action_result.data.\*.start_time | numeric | | 1554413327061 action_result.data.\*.status | string | | CLOSED action_result.data.\*.username_count | numeric | `user name` | 0 action_result.summary.flow_count | numeric | | 0 action_result.summary.name | string | | Anomaly: Access to Test or Test Defined Address
-preceded by Communication with Known Watched Networks action_result.summary.source | string | `ip` | 122.122.122.122 action_result.summary.start_time | string | | 2019-04-04 21:28:47 UTC action_result.summary.status | string | | CLOSED action_result.summary.update_time | string | | 2019-05-14 10:23:03 UTC action_result.message | string | | Status: CLOSED, Source: 122.122.122.122, Update time: 2019-05-14 10:23:03 UTC, Name: Anomaly: Access to Test or Test Defined Address
-preceded by Communication with Known Watched Networks, Flow count: 0, Start time: 2019-04-04 21:28:47 UTC summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'update offense'
+action_result.status | string | | success failed |
+action_result.parameter.closing_reason_id | numeric | `qradar offense closing reason id` | 1 |
+action_result.parameter.offense_id | numeric | `qradar offense id` | 41 |
+action_result.data.\*.assigned_to | string | | admin |
+action_result.data.\*.categories | string | | Error |
+action_result.data.\*.category_count | numeric | | 4 |
+action_result.data.\*.close_time | numeric | | 1559905203000 |
+action_result.data.\*.closing_reason_id | numeric | `qradar offense closing reason id` | 1 |
+action_result.data.\*.closing_user | string | | API_token: Phantom |
+action_result.data.\*.credibility | numeric | | 4 |
+action_result.data.\*.description | string | | Anomaly: Access to Test or Test Defined Address preceded by Communication with Known Watched Networks |
+action_result.data.\*.destination_networks | string | | other |
+action_result.data.\*.device_count | numeric | | 3 |
+action_result.data.\*.domain_id | numeric | | |
+action_result.data.\*.event_count | numeric | | 2660 |
+action_result.data.\*.flow_count | numeric | | 0 |
+action_result.data.\*.follow_up | boolean | | False True |
+action_result.data.\*.id | numeric | `qradar offense id` | 41 |
+action_result.data.\*.inactive | boolean | | False True |
+action_result.data.\*.last_updated_time | numeric | | 1557829383413 |
+action_result.data.\*.local_destination_count | numeric | | 0 |
+action_result.data.\*.magnitude | numeric | | 3 |
+action_result.data.\*.offense_source | string | `ip` | 122.122.122.122 |
+action_result.data.\*.offense_type | numeric | | 0 |
+action_result.data.\*.policy_category_count | numeric | | 0 |
+action_result.data.\*.protected | boolean | | False True |
+action_result.data.\*.relevance | numeric | | 2 |
+action_result.data.\*.remote_destination_count | numeric | | 1 |
+action_result.data.\*.rules.\*.id | numeric | | |
+action_result.data.\*.rules.\*.type | string | | |
+action_result.data.\*.security_category_count | numeric | | 4 |
+action_result.data.\*.severity | numeric | | 7 |
+action_result.data.\*.source_count | numeric | | 1 |
+action_result.data.\*.source_network | string | | other |
+action_result.data.\*.start_time | numeric | | 1554413327061 |
+action_result.data.\*.status | string | | CLOSED |
+action_result.data.\*.username_count | numeric | `user name` | 0 |
+action_result.summary.flow_count | numeric | | 0 |
+action_result.summary.name | string | | Anomaly: Access to Test or Test Defined Address preceded by Communication with Known Watched Networks |
+action_result.summary.source | string | `ip` | 122.122.122.122 |
+action_result.summary.start_time | string | | 2019-04-04 21:28:47 UTC |
+action_result.summary.status | string | | CLOSED |
+action_result.summary.update_time | string | | 2019-05-14 10:23:03 UTC |
+action_result.message | string | | Status: CLOSED, Source: 122.122.122.122, Update time: 2019-05-14 10:23:03 UTC, Name: Anomaly: Access to Test or Test Defined Address preceded by Communication with Known Watched Networks, Flow count: 0, Start time: 2019-04-04 21:28:47 UTC |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'update offense'
+
 Attach a note to an offense
 
 Type: **generic** \
@@ -777,13 +1214,24 @@ Read only: **False**
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**offense_id** | required | Offense ID to attach note to | numeric | `qradar offense id` **note_text** | required | Text to put into note | string |
+**offense_id** | required | Offense ID to attach note to | numeric | `qradar offense id` |
+**note_text** | required | Text to put into note | string | |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.note_text | string | | Note Added By Phantom action_result.parameter.offense_id | numeric | `qradar offense id` | 41 action_result.data | string | | action_result.summary | string | | action_result.message | string | | Successfully added note to offense summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'assign user'
+action_result.status | string | | success failed |
+action_result.parameter.note_text | string | | Note Added By Phantom |
+action_result.parameter.offense_id | numeric | `qradar offense id` | 41 |
+action_result.data | string | | |
+action_result.summary | string | | |
+action_result.message | string | | Successfully added note to offense |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'assign user'
+
 Assign the user to an offense
 
 Type: **generic** \
@@ -793,13 +1241,24 @@ Read only: **False**
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**offense_id** | required | Offense ID to assign the user to | numeric | `qradar offense id` **assignee** | required | Name of the user | string |
+**offense_id** | required | Offense ID to assign the user to | numeric | `qradar offense id` |
+**assignee** | required | Name of the user | string | |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.assignee | string | | admin action_result.parameter.offense_id | numeric | `qradar offense id` | 41 action_result.data | string | | action_result.summary | string | | action_result.message | string | | Successfully assigned user to offense summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'get rule info'
+action_result.status | string | | success failed |
+action_result.parameter.assignee | string | | admin |
+action_result.parameter.offense_id | numeric | `qradar offense id` | 41 |
+action_result.data | string | | |
+action_result.summary | string | | |
+action_result.message | string | | Successfully assigned user to offense |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'get rule info'
+
 Retrieve QRadar rule information
 
 Type: **investigate** \
@@ -809,13 +1268,36 @@ Read only: **True**
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**rule_id** | required | Rule ID for which information needs to be extracted | numeric | `qradar rule id`
+**rule_id** | required | Rule ID for which information needs to be extracted | numeric | `qradar rule id` |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.rule_id | numeric | `qradar rule id` | 1421 action_result.data.\*.average_capacity | numeric | | 3541750 action_result.data.\*.base_capacity | numeric | | 3541750 action_result.data.\*.base_host_id | numeric | | 384 action_result.data.\*.capacity_timestamp | numeric | | 1566896735557 action_result.data.\*.creation_date | numeric | | 1155662266056 action_result.data.\*.enabled | boolean | | True False action_result.data.\*.id | numeric | | 1421 action_result.data.\*.identifier | string | | SYSTEM-1421 action_result.data.\*.linked_rule_identifier | string | | action_result.data.\*.modification_date | numeric | | 1267729985038 action_result.data.\*.name | string | | User:BB:FalsePositives: User Defined Server Type 2 False Positive Categories action_result.data.\*.origin | string | | SYSTEM action_result.data.\*.owner | string | | admin action_result.data.\*.type | string | | EVENT action_result.summary.id | numeric | | 1421 action_result.summary.name | string | | User:BB:FalsePositives: User Defined Server Type 2 False Positive Categories action_result.message | string | | Id: 1421, Name: User:BB:FalsePositives: User Defined Server Type 2 False Positive Categories summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'list rules'
+action_result.status | string | | success failed |
+action_result.parameter.rule_id | numeric | `qradar rule id` | 1421 |
+action_result.data.\*.average_capacity | numeric | | 3541750 |
+action_result.data.\*.base_capacity | numeric | | 3541750 |
+action_result.data.\*.base_host_id | numeric | | 384 |
+action_result.data.\*.capacity_timestamp | numeric | | 1566896735557 |
+action_result.data.\*.creation_date | numeric | | 1155662266056 |
+action_result.data.\*.enabled | boolean | | True False |
+action_result.data.\*.id | numeric | | 1421 |
+action_result.data.\*.identifier | string | | SYSTEM-1421 |
+action_result.data.\*.linked_rule_identifier | string | | |
+action_result.data.\*.modification_date | numeric | | 1267729985038 |
+action_result.data.\*.name | string | | User:BB:FalsePositives: User Defined Server Type 2 False Positive Categories |
+action_result.data.\*.origin | string | | SYSTEM |
+action_result.data.\*.owner | string | | admin |
+action_result.data.\*.type | string | | EVENT |
+action_result.summary.id | numeric | | 1421 |
+action_result.summary.name | string | | User:BB:FalsePositives: User Defined Server Type 2 False Positive Categories |
+action_result.message | string | | Id: 1421, Name: User:BB:FalsePositives: User Defined Server Type 2 False Positive Categories |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'list rules'
+
 List all QRadar rules
 
 Type: **investigate** \
@@ -825,13 +1307,35 @@ Read only: **True**
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**count** | optional | Number of rules to retrieve | numeric |
+**count** | optional | Number of rules to retrieve | numeric | |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.count | numeric | | 31 action_result.data.\*.average_capacity | numeric | | 3541750 action_result.data.\*.base_capacity | numeric | | 3541750 action_result.data.\*.base_host_id | numeric | | 384 action_result.data.\*.capacity_timestamp | numeric | | 1566896735557 action_result.data.\*.creation_date | numeric | | 1155662266056 action_result.data.\*.enabled | boolean | | True False action_result.data.\*.id | numeric | `qradar rule id` | 1421 action_result.data.\*.identifier | string | | SYSTEM-1421 action_result.data.\*.linked_rule_identifier | string | | action_result.data.\*.modification_date | numeric | | 1267729985038 action_result.data.\*.name | string | | User:BB:FalsePositives: User Defined Server Type 2 False Positive Categories action_result.data.\*.origin | string | | SYSTEM action_result.data.\*.owner | string | | admin action_result.data.\*.type | string | | EVENT action_result.summary.total_rules | numeric | | 135 action_result.message | string | | Total rules: 135 summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'on poll'
+action_result.status | string | | success failed |
+action_result.parameter.count | numeric | | 31 |
+action_result.data.\*.average_capacity | numeric | | 3541750 |
+action_result.data.\*.base_capacity | numeric | | 3541750 |
+action_result.data.\*.base_host_id | numeric | | 384 |
+action_result.data.\*.capacity_timestamp | numeric | | 1566896735557 |
+action_result.data.\*.creation_date | numeric | | 1155662266056 |
+action_result.data.\*.enabled | boolean | | True False |
+action_result.data.\*.id | numeric | `qradar rule id` | 1421 |
+action_result.data.\*.identifier | string | | SYSTEM-1421 |
+action_result.data.\*.linked_rule_identifier | string | | |
+action_result.data.\*.modification_date | numeric | | 1267729985038 |
+action_result.data.\*.name | string | | User:BB:FalsePositives: User Defined Server Type 2 False Positive Categories |
+action_result.data.\*.origin | string | | SYSTEM |
+action_result.data.\*.owner | string | | admin |
+action_result.data.\*.type | string | | EVENT |
+action_result.summary.total_rules | numeric | | 135 |
+action_result.message | string | | Total rules: 135 |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'on poll'
+
 Callback action for the on_poll ingest functionality
 
 Type: **ingest** \
@@ -843,7 +1347,11 @@ The default start_time is the past 5 days. The default end_time is now.
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**container_id** | optional | Parameter ignored for this app | string | **start_time** | optional | Start of time range, in epoch time (milliseconds) | numeric | **end_time** | optional | End of time range, in epoch time (milliseconds) | numeric | **container_count** | optional | Maximum number of container records to query for | numeric | **artifact_count** | optional | Parameter ignored for this app | numeric |
+**container_id** | optional | Parameter ignored for this app | string | |
+**start_time** | optional | Start of time range, in epoch time (milliseconds) | numeric | |
+**end_time** | optional | End of time range, in epoch time (milliseconds) | numeric | |
+**container_count** | optional | Maximum number of container records to query for | numeric | |
+**artifact_count** | optional | Parameter ignored for this app | numeric | |
 
 #### Action Output
 

--- a/github-actions/start-release/tests/data/build_docs/has_no_readme/expected_readme.md
+++ b/github-actions/start-release/tests/data/build_docs/has_no_readme/expected_readme.md
@@ -14,30 +14,30 @@ This table lists the configuration variables required to operate QRadar. These v
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------
-**device** | required | string | Server IP/Hostname
-**containers_only** | optional | boolean | Ingest only offenses while polling
-**has_offense** | optional | boolean | Fetch only events and flows associated with the offense
-**verify_server_cert** | optional | boolean | Verify server certificate
-**username** | optional | string | Username
-**password** | optional | password | Password
-**authorization_token** | optional | password | Auth Token for QRadar REST API calls
-**timezone** | required | timezone | QRadar timezone
-**add_to_resolved** | optional | boolean | Ingest artifacts into closed/resolved containers
-**artifact_max** | optional | numeric | Maximum event artifacts count per cycle (excluding the default generated offense artifact)
-**ingest_resolved** | optional | boolean | Ingest only open offenses
-**cef_event_map** | optional | string | CEF event map
-**cef_value_map** | optional | string | CEF value map
-**delete_empty_cef_fields** | optional | boolean | Delete the empty CEF fields
-**event_fields_for_query** | optional | string | Event fields to include while querying
-**add_offense_id_to_name** | optional | boolean | Add offense ID to name of containers
-**alternative_ariel_query** | optional | boolean | Alternative ariel query
-**alternative_ingest_algorithm** | optional | boolean | Alternative ingest algorithm for offenses
-**alt_time_field** | optional | string | Alternative ingestion time field
-**alt_initial_ingest_time** | optional | string | Alternative initial ingestion time
-**alt_ingestion_order** | optional | string | Alternative ingestion order for offenses
-**events_ingest_start_time** | optional | numeric | Events ingestion initial time (relative to offense start time, default is 60 min)
-**offense_ingest_start_time** | optional | numeric | Offense ingestion initial time (relative to offense start time, default is 0 min)
-**event_ingest_end_time** | optional | numeric | Events ingestion end time (relative to event ingestion start time, default is 0 min)
+**device** | required | string | Server IP/Hostname |
+**containers_only** | optional | boolean | Ingest only offenses while polling |
+**has_offense** | optional | boolean | Fetch only events and flows associated with the offense |
+**verify_server_cert** | optional | boolean | Verify server certificate |
+**username** | optional | string | Username |
+**password** | optional | password | Password |
+**authorization_token** | optional | password | Auth Token for QRadar REST API calls |
+**timezone** | required | timezone | QRadar timezone |
+**add_to_resolved** | optional | boolean | Ingest artifacts into closed/resolved containers |
+**artifact_max** | optional | numeric | Maximum event artifacts count per cycle (excluding the default generated offense artifact) |
+**ingest_resolved** | optional | boolean | Ingest only open offenses |
+**cef_event_map** | optional | string | CEF event map |
+**cef_value_map** | optional | string | CEF value map |
+**delete_empty_cef_fields** | optional | boolean | Delete the empty CEF fields |
+**event_fields_for_query** | optional | string | Event fields to include while querying |
+**add_offense_id_to_name** | optional | boolean | Add offense ID to name of containers |
+**alternative_ariel_query** | optional | boolean | Alternative ariel query |
+**alternative_ingest_algorithm** | optional | boolean | Alternative ingest algorithm for offenses |
+**alt_time_field** | optional | string | Alternative ingestion time field |
+**alt_initial_ingest_time** | optional | string | Alternative initial ingestion time |
+**alt_ingestion_order** | optional | string | Alternative ingestion order for offenses |
+**events_ingest_start_time** | optional | numeric | Events ingestion initial time (relative to offense start time, default is 60 min) |
+**offense_ingest_start_time** | optional | numeric | Offense ingestion initial time (relative to offense start time, default is 0 min) |
+**event_ingest_end_time** | optional | numeric | Events ingestion end time (relative to event ingestion start time, default is 0 min) |
 
 ### Supported Actions
 
@@ -85,14 +85,62 @@ The default start_time is the past 5 days. The default end_time is now. The defa
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**start_time** | optional | Start of time range, in epoch time (milliseconds) | numeric | **end_time** | optional | End of time range, in epoch time (milliseconds) | numeric | **count** | optional | Number of offenses to retrieve | numeric | **offense_id** | optional | Comma-separated list of offense IDs to fetch | string | `qradar offense id`
+**start_time** | optional | Start of time range, in epoch time (milliseconds) | numeric | |
+**end_time** | optional | End of time range, in epoch time (milliseconds) | numeric | |
+**count** | optional | Number of offenses to retrieve | numeric | |
+**offense_id** | optional | Comma-separated list of offense IDs to fetch | string | `qradar offense id` |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.count | numeric | | 100 action_result.parameter.end_time | numeric | | 1669900000000 action_result.parameter.offense_id | string | `qradar offense id` | 44 action_result.parameter.start_time | numeric | | 1559900000000 action_result.data.\*.assigned_to | string | | admin action_result.data.\*.categories | string | | License Status action_result.data.\*.category_count | numeric | | 10 action_result.data.\*.close_time | string | | action_result.data.\*.closing_reason_id | string | `qradar offense closing reason id` | action_result.data.\*.closing_user | string | | action_result.data.\*.credibility | numeric | | 4 action_result.data.\*.description | string | | Local Malware Events
-action_result.data.\*.destination_networks | string | | other action_result.data.\*.device_count | numeric | | 3 action_result.data.\*.domain_id | numeric | | action_result.data.\*.event_count | numeric | | 28603163 action_result.data.\*.flow_count | numeric | | 110 action_result.data.\*.follow_up | boolean | | False True action_result.data.\*.id | numeric | `qradar offense id` | 44 action_result.data.\*.inactive | boolean | | False True action_result.data.\*.last_updated_time | numeric | | 1559194600958 action_result.data.\*.local_destination_count | numeric | | 0 action_result.data.\*.magnitude | numeric | | 5 action_result.data.\*.offense_source | string | `ip` | 122.122.122.122 action_result.data.\*.offense_type | numeric | | 0 action_result.data.\*.policy_category_count | numeric | | 0 action_result.data.\*.protected | boolean | | False True action_result.data.\*.relevance | numeric | | 4 action_result.data.\*.remote_destination_count | numeric | | 1 action_result.data.\*.rules.\*.id | numeric | | action_result.data.\*.rules.\*.type | string | | action_result.data.\*.security_category_count | numeric | | 10 action_result.data.\*.severity | numeric | | 6 action_result.data.\*.source_count | numeric | | 1 action_result.data.\*.source_network | string | | Net-10-172-192.Net_10_0_0_0 action_result.data.\*.start_time | numeric | | 1558009780686 action_result.data.\*.status | string | | OPEN action_result.data.\*.username_count | numeric | `user name` | 0 action_result.summary | string | | action_result.summary.total_offenses | numeric | | 1 action_result.message | string | | Fetching all open offenses. Total offenses: 1 Total Offenses: 1 summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'list closing reasons'
+action_result.status | string | | success failed |
+action_result.parameter.count | numeric | | 100 |
+action_result.parameter.end_time | numeric | | 1669900000000 |
+action_result.parameter.offense_id | string | `qradar offense id` | 44 |
+action_result.parameter.start_time | numeric | | 1559900000000 |
+action_result.data.\*.assigned_to | string | | admin |
+action_result.data.\*.categories | string | | License Status |
+action_result.data.\*.category_count | numeric | | 10 |
+action_result.data.\*.close_time | string | | |
+action_result.data.\*.closing_reason_id | string | `qradar offense closing reason id` | |
+action_result.data.\*.closing_user | string | | |
+action_result.data.\*.credibility | numeric | | 4 |
+action_result.data.\*.description | string | | Local Malware Events |
+action_result.data.\*.destination_networks | string | | other |
+action_result.data.\*.device_count | numeric | | 3 |
+action_result.data.\*.domain_id | numeric | | |
+action_result.data.\*.event_count | numeric | | 28603163 |
+action_result.data.\*.flow_count | numeric | | 110 |
+action_result.data.\*.follow_up | boolean | | False True |
+action_result.data.\*.id | numeric | `qradar offense id` | 44 |
+action_result.data.\*.inactive | boolean | | False True |
+action_result.data.\*.last_updated_time | numeric | | 1559194600958 |
+action_result.data.\*.local_destination_count | numeric | | 0 |
+action_result.data.\*.magnitude | numeric | | 5 |
+action_result.data.\*.offense_source | string | `ip` | 122.122.122.122 |
+action_result.data.\*.offense_type | numeric | | 0 |
+action_result.data.\*.policy_category_count | numeric | | 0 |
+action_result.data.\*.protected | boolean | | False True |
+action_result.data.\*.relevance | numeric | | 4 |
+action_result.data.\*.remote_destination_count | numeric | | 1 |
+action_result.data.\*.rules.\*.id | numeric | | |
+action_result.data.\*.rules.\*.type | string | | |
+action_result.data.\*.security_category_count | numeric | | 10 |
+action_result.data.\*.severity | numeric | | 6 |
+action_result.data.\*.source_count | numeric | | 1 |
+action_result.data.\*.source_network | string | | Net-10-172-192.Net_10_0_0_0 |
+action_result.data.\*.start_time | numeric | | 1558009780686 |
+action_result.data.\*.status | string | | OPEN |
+action_result.data.\*.username_count | numeric | `user name` | 0 |
+action_result.summary | string | | |
+action_result.summary.total_offenses | numeric | | 1 |
+action_result.message | string | | Fetching all open offenses. Total offenses: 1 Total Offenses: 1 |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'list closing reasons'
+
 Get a list of offense closing reasons
 
 Type: **investigate** \
@@ -102,13 +150,27 @@ Read only: **True**
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**include_reserved** | optional | Include reserved offense closing reasons | boolean | **include_deleted** | optional | Include deleted offense closing reasons | boolean |
+**include_reserved** | optional | Include reserved offense closing reasons | boolean | |
+**include_deleted** | optional | Include deleted offense closing reasons | boolean | |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.include_deleted | boolean | | True False action_result.parameter.include_reserved | boolean | | True False action_result.data.\*.id | numeric | `qradar offense closing reason id` | 2 action_result.data.\*.is_deleted | boolean | | True False action_result.data.\*.is_reserved | boolean | | True False action_result.data.\*.text | string | | False-Positive, Tuned action_result.summary.total_offense_closing_reasons | numeric | | 5 action_result.message | string | | Total offense closing reasons: 5 summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'get events'
+action_result.status | string | | success failed |
+action_result.parameter.include_deleted | boolean | | True False |
+action_result.parameter.include_reserved | boolean | | True False |
+action_result.data.\*.id | numeric | `qradar offense closing reason id` | 2 |
+action_result.data.\*.is_deleted | boolean | | True False |
+action_result.data.\*.is_reserved | boolean | | True False |
+action_result.data.\*.text | string | | False-Positive, Tuned |
+action_result.summary.total_offense_closing_reasons | numeric | | 5 |
+action_result.message | string | | Total offense closing reasons: 5 |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'get events'
+
 Get events belonging to an offense
 
 Type: **investigate** \
@@ -120,13 +182,72 @@ Use fields_filter parameter to restrict the events returned that match the filte
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**offense_id** | optional | Offense ID to get events of | numeric | `qradar offense id` **start_time** | optional | Start of time range, in epoch time (milliseconds) | numeric | **end_time** | optional | End of time range, in epoch time (milliseconds) | numeric | **count** | optional | Number of events to retrieve | numeric | **fields_filter** | optional | Filter on event field values | string | **interval_days** | optional | Interval days | numeric |
+**offense_id** | optional | Offense ID to get events of | numeric | `qradar offense id` |
+**start_time** | optional | Start of time range, in epoch time (milliseconds) | numeric | |
+**end_time** | optional | End of time range, in epoch time (milliseconds) | numeric | |
+**count** | optional | Number of events to retrieve | numeric | |
+**fields_filter** | optional | Filter on event field values | string | |
+**interval_days** | optional | Interval days | numeric | |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.count | numeric | | 10 action_result.parameter.end_time | numeric | | 1669891174855 action_result.parameter.fields_filter | string | | sourceip='122.122.122.122' action_result.parameter.interval_days | numeric | | 20 action_result.parameter.offense_id | numeric | `qradar offense id` | 44 action_result.parameter.start_time | numeric | | 1559891174855 action_result.data.\*.AccountDomain | string | `domain` `url` | action_result.data.\*.Application | string | | action_result.data.\*.Bytes | string | | action_result.data.\*.BytesReceived | string | | action_result.data.\*.BytesSent | string | | action_result.data.\*.Destination Host Name | string | `host name` | action_result.data.\*.EventID | string | | action_result.data.\*.File Hash | string | | action_result.data.\*.File ID | string | | action_result.data.\*.File Path | string | | action_result.data.\*.Filename | string | | action_result.data.\*.Hostname | string | `host name` | action_result.data.\*.Installer Filename | string | | action_result.data.\*.Message | string | | action_result.data.\*.Payload | string | | Communication with Known Watched Networks There has been event communication with networks that appear on the systems watch and darknet lists. action_result.data.\*.Source Host Name | string | `host name` | action_result.data.\*.categoryname_category | string | | Suspicious Activity action_result.data.\*.destinationaddress | string | `ip` | 122.122.122.122 action_result.data.\*.destinationip | string | `ip` | 122.122.122.122 action_result.data.\*.destinationmac | string | | 00:00:00:00:00:00 action_result.data.\*.destinationport | numeric | `port` | 0 action_result.data.\*.endtime | numeric | | action_result.data.\*.eventcount | numeric | | action_result.data.\*.eventdirection | string | | L2R R2R action_result.data.\*.hostname_logsourceid | string | `host name` | Unknown Host 63 action_result.data.\*.identityip | string | `ip` | action_result.data.\*.logsourcegroupname_logsourceid | string | | Other action_result.data.\*.logsourceid | numeric | | 63 action_result.data.\*.logsourcename_logsourceid | string | | Custom Rule Engine-8 :: qradar action_result.data.\*.protocolname_protocolid | string | | Reserved action_result.data.\*.qid | numeric | | 70750119 action_result.data.\*.qidname_qid | string | | Communication with Known Watched Networks action_result.data.\*.relevance | numeric | | action_result.data.\*.severity | numeric | | action_result.data.\*.sourceaddress | string | `ip` | 122.122.122.122 action_result.data.\*.sourceip | string | `ip` | 122.122.122.122 action_result.data.\*.sourcemac | string | | 00:00:00:00:00:00 action_result.data.\*.sourceport | numeric | `port` | 0 action_result.data.\*.sourcev6 | string | `ipv6` | action_result.data.\*.starttime | numeric | | 1559194870184 action_result.data.\*.username | string | `user name` | action_result.summary.total_events | numeric | | 10 action_result.message | string | | Total events: 10 summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'get flows'
+action_result.status | string | | success failed |
+action_result.parameter.count | numeric | | 10 |
+action_result.parameter.end_time | numeric | | 1669891174855 |
+action_result.parameter.fields_filter | string | | sourceip='122.122.122.122' |
+action_result.parameter.interval_days | numeric | | 20 |
+action_result.parameter.offense_id | numeric | `qradar offense id` | 44 |
+action_result.parameter.start_time | numeric | | 1559891174855 |
+action_result.data.\*.AccountDomain | string | `domain` `url` | |
+action_result.data.\*.Application | string | | |
+action_result.data.\*.Bytes | string | | |
+action_result.data.\*.BytesReceived | string | | |
+action_result.data.\*.BytesSent | string | | |
+action_result.data.\*.Destination Host Name | string | `host name` | |
+action_result.data.\*.EventID | string | | |
+action_result.data.\*.File Hash | string | | |
+action_result.data.\*.File ID | string | | |
+action_result.data.\*.File Path | string | | |
+action_result.data.\*.Filename | string | | |
+action_result.data.\*.Hostname | string | `host name` | |
+action_result.data.\*.Installer Filename | string | | |
+action_result.data.\*.Message | string | | |
+action_result.data.\*.Payload | string | | Communication with Known Watched Networks There has been event communication with networks that appear on the systems watch and darknet lists. |
+action_result.data.\*.Source Host Name | string | `host name` | |
+action_result.data.\*.categoryname_category | string | | Suspicious Activity |
+action_result.data.\*.destinationaddress | string | `ip` | 122.122.122.122 |
+action_result.data.\*.destinationip | string | `ip` | 122.122.122.122 |
+action_result.data.\*.destinationmac | string | | 00:00:00:00:00:00 |
+action_result.data.\*.destinationport | numeric | `port` | 0 |
+action_result.data.\*.endtime | numeric | | |
+action_result.data.\*.eventcount | numeric | | |
+action_result.data.\*.eventdirection | string | | L2R R2R |
+action_result.data.\*.hostname_logsourceid | string | `host name` | Unknown Host 63 |
+action_result.data.\*.identityip | string | `ip` | |
+action_result.data.\*.logsourcegroupname_logsourceid | string | | Other |
+action_result.data.\*.logsourceid | numeric | | 63 |
+action_result.data.\*.logsourcename_logsourceid | string | | Custom Rule Engine-8 :: qradar |
+action_result.data.\*.protocolname_protocolid | string | | Reserved |
+action_result.data.\*.qid | numeric | | 70750119 |
+action_result.data.\*.qidname_qid | string | | Communication with Known Watched Networks |
+action_result.data.\*.relevance | numeric | | |
+action_result.data.\*.severity | numeric | | |
+action_result.data.\*.sourceaddress | string | `ip` | 122.122.122.122 |
+action_result.data.\*.sourceip | string | `ip` | 122.122.122.122 |
+action_result.data.\*.sourcemac | string | | 00:00:00:00:00:00 |
+action_result.data.\*.sourceport | numeric | `port` | 0 |
+action_result.data.\*.sourcev6 | string | `ipv6` | |
+action_result.data.\*.starttime | numeric | | 1559194870184 |
+action_result.data.\*.username | string | `user name` | |
+action_result.summary.total_events | numeric | | 10 |
+action_result.message | string | | Total events: 10 |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'get flows'
+
 Get flows that make up an offense for a particular IP
 
 Type: **investigate** \
@@ -138,13 +259,121 @@ Use the <b>fields_filter</b> parameter to restrict the flows returned. For e.g. 
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**ip** | optional | IP to get all the flows of | string | `ip` **offense_id** | optional | Offense ID to get flows of | numeric | `qradar offense id` **start_time** | optional | Start of time range, in epoch time (milliseconds) | numeric | **end_time** | optional | End of time range, in epoch time (milliseconds) | numeric | **count** | optional | Number of flows to retrieve | numeric | **fields_filter** | optional | Filter in AQL format on flow field values | string |
+**ip** | optional | IP to get all the flows of | string | `ip` |
+**offense_id** | optional | Offense ID to get flows of | numeric | `qradar offense id` |
+**start_time** | optional | Start of time range, in epoch time (milliseconds) | numeric | |
+**end_time** | optional | End of time range, in epoch time (milliseconds) | numeric | |
+**count** | optional | Number of flows to retrieve | numeric | |
+**fields_filter** | optional | Filter in AQL format on flow field values | string | |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.count | numeric | | 100 action_result.parameter.end_time | numeric | | 1559905203000 action_result.parameter.fields_filter | string | | sourceip='127.0.0.1' action_result.parameter.ip | string | `ip` | 122.122.122.122 action_result.parameter.offense_id | numeric | `qradar offense id` | 41 action_result.parameter.start_time | numeric | | 1559905201000 action_result.data.\*.Action | string | | action_result.data.\*.Application Determination Algorithm | numeric | | action_result.data.\*.Content Subject | string | | action_result.data.\*.Content Type | string | | action_result.data.\*.FTP Pass | string | | action_result.data.\*.FTP RETR File | string | | action_result.data.\*.FTP User | string | | action_result.data.\*.File Entropy | string | | action_result.data.\*.File Hash | string | | action_result.data.\*.File Name | string | | action_result.data.\*.File Size | string | | action_result.data.\*.Flow Direction Algorithm | numeric | | action_result.data.\*.Google Search Terms | string | | action_result.data.\*.HTTP Content-Type | string | | action_result.data.\*.HTTP GET Request | string | | action_result.data.\*.HTTP Host | string | | action_result.data.\*.HTTP Referer | string | | action_result.data.\*.HTTP Referrer | string | | action_result.data.\*.HTTP Response Code | string | | action_result.data.\*.HTTP Server | string | | action_result.data.\*.HTTP User Agent | string | | action_result.data.\*.HTTP User-Agent | string | | action_result.data.\*.HTTP Version | string | | action_result.data.\*.Originating User | string | | action_result.data.\*.Password | string | | action_result.data.\*.Request URL | string | | action_result.data.\*.SMTP From | string | | action_result.data.\*.SMTP HELO | string | | action_result.data.\*.SMTP Hello | string | | action_result.data.\*.SMTP To | string | | action_result.data.\*.Search Arguments | string | | action_result.data.\*.VLAN Tag | string | | action_result.data.\*.applicationid | numeric | | 1011 action_result.data.\*.applicationname_applicationid | string | | action_result.data.\*.category | numeric | | 18448 action_result.data.\*.categoryname_category | string | | action_result.data.\*.credibility | numeric | | 10 action_result.data.\*.destinationasn | string | | action_result.data.\*.destinationbytes | numeric | | 11567 action_result.data.\*.destinationdscp | numeric | | action_result.data.\*.destinationflags | string | | action_result.data.\*.destinationifindex | string | | action_result.data.\*.destinationip | string | `ip` | 10.1.16.15 action_result.data.\*.destinationpackets | numeric | | 108 action_result.data.\*.destinationpayload | string | | action_result.data.\*.destinationport | numeric | `port` | 3365 action_result.data.\*.destinationprecedence | numeric | | action_result.data.\*.destinationv6 | string | | 0:0:0:0:0:0:0:0 action_result.data.\*.domainid | numeric | | action_result.data.\*.firstpackettime | numeric | | 1559905202000 action_result.data.\*.flowbias | string | | action_result.data.\*.flowdirection | string | | L2R action_result.data.\*.flowid | numeric | | action_result.data.\*.flowinterface | string | | action_result.data.\*.flowinterfaceid | string | | 5 action_result.data.\*.flowsource | string | | action_result.data.\*.flowtype | numeric | | action_result.data.\*.fullmatchlist | string | | action_result.data.\*.geographic | string | | NorthAmerica.UnitedStates action_result.data.\*.hasdestinationpayload | boolean | | action_result.data.\*.hasoffense | boolean | | True action_result.data.\*.hassourcepayload | boolean | | False action_result.data.\*.hastlv | boolean | | action_result.data.\*.icmpcode | string | | action_result.data.\*.icmptype | string | | action_result.data.\*.intervalid | numeric | | 1603463820 action_result.data.\*.isduplicate | boolean | | action_result.data.\*.lastpackettime | numeric | | 1559905202999 action_result.data.\*.partialmatchlist | string | | action_result.data.\*.processorid | numeric | | 8 action_result.data.\*.protocolid | numeric | | action_result.data.\*.protocolname_protocolid | string | | action_result.data.\*.qid | numeric | | 53250087 action_result.data.\*.qidname_qid | string | | Test.Securetest action_result.data.\*.relevance | numeric | | action_result.data.\*.retentionbucket | string | | action_result.data.\*.severity | numeric | | 1 action_result.data.\*.sourceasn | string | | action_result.data.\*.sourcebytes | numeric | | 1031681 action_result.data.\*.sourcedscp | numeric | | action_result.data.\*.sourceflags | string | | action_result.data.\*.sourceifindex | string | | action_result.data.\*.sourceip | string | `ip` | 127.0.0.1 action_result.data.\*.sourcepackets | numeric | | 783 action_result.data.\*.sourcepayload | string | | action_result.data.\*.sourceport | numeric | | 4806 action_result.data.\*.sourceprecedence | numeric | | action_result.data.\*.sourcev6 | string | `ipv6` | 0:0:0:0:0:0:0:0 action_result.data.\*.starttime | numeric | | 1559905201000 action_result.data.\*.viewobjectpair | string | | action_result.summary.total_flows | numeric | | 33 action_result.message | string | | Total flows: 33 summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'offense details'
+action_result.status | string | | success failed |
+action_result.parameter.count | numeric | | 100 |
+action_result.parameter.end_time | numeric | | 1559905203000 |
+action_result.parameter.fields_filter | string | | sourceip='127.0.0.1' |
+action_result.parameter.ip | string | `ip` | 122.122.122.122 |
+action_result.parameter.offense_id | numeric | `qradar offense id` | 41 |
+action_result.parameter.start_time | numeric | | 1559905201000 |
+action_result.data.\*.Action | string | | |
+action_result.data.\*.Application Determination Algorithm | numeric | | |
+action_result.data.\*.Content Subject | string | | |
+action_result.data.\*.Content Type | string | | |
+action_result.data.\*.FTP Pass | string | | |
+action_result.data.\*.FTP RETR File | string | | |
+action_result.data.\*.FTP User | string | | |
+action_result.data.\*.File Entropy | string | | |
+action_result.data.\*.File Hash | string | | |
+action_result.data.\*.File Name | string | | |
+action_result.data.\*.File Size | string | | |
+action_result.data.\*.Flow Direction Algorithm | numeric | | |
+action_result.data.\*.Google Search Terms | string | | |
+action_result.data.\*.HTTP Content-Type | string | | |
+action_result.data.\*.HTTP GET Request | string | | |
+action_result.data.\*.HTTP Host | string | | |
+action_result.data.\*.HTTP Referer | string | | |
+action_result.data.\*.HTTP Referrer | string | | |
+action_result.data.\*.HTTP Response Code | string | | |
+action_result.data.\*.HTTP Server | string | | |
+action_result.data.\*.HTTP User Agent | string | | |
+action_result.data.\*.HTTP User-Agent | string | | |
+action_result.data.\*.HTTP Version | string | | |
+action_result.data.\*.Originating User | string | | |
+action_result.data.\*.Password | string | | |
+action_result.data.\*.Request URL | string | | |
+action_result.data.\*.SMTP From | string | | |
+action_result.data.\*.SMTP HELO | string | | |
+action_result.data.\*.SMTP Hello | string | | |
+action_result.data.\*.SMTP To | string | | |
+action_result.data.\*.Search Arguments | string | | |
+action_result.data.\*.VLAN Tag | string | | |
+action_result.data.\*.applicationid | numeric | | 1011 |
+action_result.data.\*.applicationname_applicationid | string | | |
+action_result.data.\*.category | numeric | | 18448 |
+action_result.data.\*.categoryname_category | string | | |
+action_result.data.\*.credibility | numeric | | 10 |
+action_result.data.\*.destinationasn | string | | |
+action_result.data.\*.destinationbytes | numeric | | 11567 |
+action_result.data.\*.destinationdscp | numeric | | |
+action_result.data.\*.destinationflags | string | | |
+action_result.data.\*.destinationifindex | string | | |
+action_result.data.\*.destinationip | string | `ip` | 10.1.16.15 |
+action_result.data.\*.destinationpackets | numeric | | 108 |
+action_result.data.\*.destinationpayload | string | | |
+action_result.data.\*.destinationport | numeric | `port` | 3365 |
+action_result.data.\*.destinationprecedence | numeric | | |
+action_result.data.\*.destinationv6 | string | | 0:0:0:0:0:0:0:0 |
+action_result.data.\*.domainid | numeric | | |
+action_result.data.\*.firstpackettime | numeric | | 1559905202000 |
+action_result.data.\*.flowbias | string | | |
+action_result.data.\*.flowdirection | string | | L2R |
+action_result.data.\*.flowid | numeric | | |
+action_result.data.\*.flowinterface | string | | |
+action_result.data.\*.flowinterfaceid | string | | 5 |
+action_result.data.\*.flowsource | string | | |
+action_result.data.\*.flowtype | numeric | | |
+action_result.data.\*.fullmatchlist | string | | |
+action_result.data.\*.geographic | string | | NorthAmerica.UnitedStates |
+action_result.data.\*.hasdestinationpayload | boolean | | |
+action_result.data.\*.hasoffense | boolean | | True |
+action_result.data.\*.hassourcepayload | boolean | | False |
+action_result.data.\*.hastlv | boolean | | |
+action_result.data.\*.icmpcode | string | | |
+action_result.data.\*.icmptype | string | | |
+action_result.data.\*.intervalid | numeric | | 1603463820 |
+action_result.data.\*.isduplicate | boolean | | |
+action_result.data.\*.lastpackettime | numeric | | 1559905202999 |
+action_result.data.\*.partialmatchlist | string | | |
+action_result.data.\*.processorid | numeric | | 8 |
+action_result.data.\*.protocolid | numeric | | |
+action_result.data.\*.protocolname_protocolid | string | | |
+action_result.data.\*.qid | numeric | | 53250087 |
+action_result.data.\*.qidname_qid | string | | Test.Securetest |
+action_result.data.\*.relevance | numeric | | |
+action_result.data.\*.retentionbucket | string | | |
+action_result.data.\*.severity | numeric | | 1 |
+action_result.data.\*.sourceasn | string | | |
+action_result.data.\*.sourcebytes | numeric | | 1031681 |
+action_result.data.\*.sourcedscp | numeric | | |
+action_result.data.\*.sourceflags | string | | |
+action_result.data.\*.sourceifindex | string | | |
+action_result.data.\*.sourceip | string | `ip` | 127.0.0.1 |
+action_result.data.\*.sourcepackets | numeric | | 783 |
+action_result.data.\*.sourcepayload | string | | |
+action_result.data.\*.sourceport | numeric | | 4806 |
+action_result.data.\*.sourceprecedence | numeric | | |
+action_result.data.\*.sourcev6 | string | `ipv6` | 0:0:0:0:0:0:0:0 |
+action_result.data.\*.starttime | numeric | | 1559905201000 |
+action_result.data.\*.viewobjectpair | string | | |
+action_result.summary.total_flows | numeric | | 33 |
+action_result.message | string | | Total flows: 33 |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'offense details'
+
 Get details about an offense
 
 Type: **investigate** \
@@ -156,16 +385,65 @@ If the <b>ingest_offense</b> parameter is checked, then, it will ingest the even
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**offense_id** | required | Offense ID to get the details of | numeric | `qradar offense id` **tenant_id** | optional | Tenant ID for saving container | numeric | **ingest_offense** | optional | Ingest offense into Phantom | boolean |
+**offense_id** | required | Offense ID to get the details of | numeric | `qradar offense id` |
+**tenant_id** | optional | Tenant ID for saving container | numeric | |
+**ingest_offense** | optional | Ingest offense into Phantom | boolean | |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.ingest_offense | boolean | | True False action_result.parameter.offense_id | numeric | `qradar offense id` | 43 action_result.parameter.tenant_id | numeric | | 123 action_result.data.\*.assigned_to | string | | admin action_result.data.\*.categories | string | | Error action_result.data.\*.category_count | numeric | | 4 action_result.data.\*.close_time | string | | 1602888300000 action_result.data.\*.closing_reason_id | string | `qradar offense closing reason id` | 3 action_result.data.\*.closing_user | string | | root action_result.data.\*.credibility | numeric | | 4 action_result.data.\*.description | string | | Anomaly: Access to Test or Test Defined Address
-preceded by Communication with Known Watched Networks
-action_result.data.\*.destination_networks | string | | other action_result.data.\*.device_count | numeric | | 3 action_result.data.\*.domain_id | numeric | | action_result.data.\*.event_count | numeric | | 1035 action_result.data.\*.flow_count | numeric | | 0 action_result.data.\*.follow_up | boolean | | False True action_result.data.\*.id | numeric | `qradar offense id` | 43 action_result.data.\*.inactive | boolean | | False True action_result.data.\*.last_updated_time | numeric | | 1559125383270 action_result.data.\*.local_destination_count | numeric | | 0 action_result.data.\*.magnitude | numeric | | 4 action_result.data.\*.offense_source | string | `ip` | 122.122.122.122 action_result.data.\*.offense_type | numeric | | 0 action_result.data.\*.policy_category_count | numeric | | 0 action_result.data.\*.protected | boolean | | False True action_result.data.\*.relevance | numeric | | 2 action_result.data.\*.remote_destination_count | numeric | | 1 action_result.data.\*.rules.\*.id | numeric | | action_result.data.\*.rules.\*.type | string | | action_result.data.\*.security_category_count | numeric | | 4 action_result.data.\*.severity | numeric | | 7 action_result.data.\*.source_count | numeric | | 1 action_result.data.\*.source_network | string | | other action_result.data.\*.start_time | numeric | | 1558008289506 action_result.data.\*.status | string | | OPEN action_result.data.\*.username_count | numeric | `user name` | 0 action_result.summary.flow_count | numeric | | 0 action_result.summary.name | string | | Anomaly: Access to Test or Test Defined Address
-preceded by Communication with Known Watched Networks action_result.summary.source | string | `ip` | 122.122.122.122 action_result.summary.start_time | string | | 2019-04-04 21:28:47 UTC action_result.summary.status | string | | OPEN action_result.summary.total_offenses | numeric | | 1 action_result.summary.update_time | string | | 2019-05-14 10:23:03 UTC action_result.message | string | | Total offenses: 1 summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'alt manage ingestion'
+action_result.status | string | | success failed |
+action_result.parameter.ingest_offense | boolean | | True False |
+action_result.parameter.offense_id | numeric | `qradar offense id` | 43 |
+action_result.parameter.tenant_id | numeric | | 123 |
+action_result.data.\*.assigned_to | string | | admin |
+action_result.data.\*.categories | string | | Error |
+action_result.data.\*.category_count | numeric | | 4 |
+action_result.data.\*.close_time | string | | 1602888300000 |
+action_result.data.\*.closing_reason_id | string | `qradar offense closing reason id` | 3 |
+action_result.data.\*.closing_user | string | | root |
+action_result.data.\*.credibility | numeric | | 4 |
+action_result.data.\*.description | string | | Anomaly: Access to Test or Test Defined Address preceded by Communication with Known Watched Networks |
+action_result.data.\*.destination_networks | string | | other |
+action_result.data.\*.device_count | numeric | | 3 |
+action_result.data.\*.domain_id | numeric | | |
+action_result.data.\*.event_count | numeric | | 1035 |
+action_result.data.\*.flow_count | numeric | | 0 |
+action_result.data.\*.follow_up | boolean | | False True |
+action_result.data.\*.id | numeric | `qradar offense id` | 43 |
+action_result.data.\*.inactive | boolean | | False True |
+action_result.data.\*.last_updated_time | numeric | | 1559125383270 |
+action_result.data.\*.local_destination_count | numeric | | 0 |
+action_result.data.\*.magnitude | numeric | | 4 |
+action_result.data.\*.offense_source | string | `ip` | 122.122.122.122 |
+action_result.data.\*.offense_type | numeric | | 0 |
+action_result.data.\*.policy_category_count | numeric | | 0 |
+action_result.data.\*.protected | boolean | | False True |
+action_result.data.\*.relevance | numeric | | 2 |
+action_result.data.\*.remote_destination_count | numeric | | 1 |
+action_result.data.\*.rules.\*.id | numeric | | |
+action_result.data.\*.rules.\*.type | string | | |
+action_result.data.\*.security_category_count | numeric | | 4 |
+action_result.data.\*.severity | numeric | | 7 |
+action_result.data.\*.source_count | numeric | | 1 |
+action_result.data.\*.source_network | string | | other |
+action_result.data.\*.start_time | numeric | | 1558008289506 |
+action_result.data.\*.status | string | | OPEN |
+action_result.data.\*.username_count | numeric | `user name` | 0 |
+action_result.summary.flow_count | numeric | | 0 |
+action_result.summary.name | string | | Anomaly: Access to Test or Test Defined Address preceded by Communication with Known Watched Networks |
+action_result.summary.source | string | `ip` | 122.122.122.122 |
+action_result.summary.start_time | string | | 2019-04-04 21:28:47 UTC |
+action_result.summary.status | string | | OPEN |
+action_result.summary.total_offenses | numeric | | 1 |
+action_result.summary.update_time | string | | 2019-05-14 10:23:03 UTC |
+action_result.message | string | | Total offenses: 1 |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'alt manage ingestion'
+
 Manage ingestion details
 
 Type: **generic** \
@@ -177,13 +455,45 @@ The general structure of the state file is {"app_version":"app_version", "last_s
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**operation** | required | Operation to perform on the ingestion data stored in the state file | string | **datetime** | optional | Datetime string to be stored against the ingestion data in the state file | string | **offense_id** | optional | Offense ID against which to store the 'datetime' parameter value | string | `qradar offense id`
+**operation** | required | Operation to perform on the ingestion data stored in the state file | string | |
+**datetime** | optional | Datetime string to be stored against the ingestion data in the state file | string | |
+**offense_id** | optional | Offense ID against which to store the 'datetime' parameter value | string | `qradar offense id` |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.datetime | string | | 2019-12-09 11:11:11.0001 action_result.parameter.offense_id | numeric | `qradar offense id` | 4 action_result.parameter.operation | string | | get last saved ingestion time data action_result.data.\*.last_ingested_events_ingest_time | string | | Offense ID_1=Fri Nov 29 10:05:25 2019 UTC +0000, Offense ID_3=Fri Nov 29 10:01:24 2019 UTC +0000, Offense ID_2=Fri Nov 29 10:03:18 2019 UTC +0000 action_result.data.\*.last_ingested_events_ingest_time_as_epoch.1 | numeric | | 1575021925702 action_result.data.\*.last_ingested_events_ingest_time_as_epoch.10 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.19 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.20 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.21 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.22 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.23 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.24 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.74 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.75 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.76 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.77 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.78 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.79 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.80 | numeric | | action_result.data.\*.last_ingested_events_ingest_time_as_epoch.82 | numeric | | action_result.data.\*.last_saved_offense_ingest_time | string | | Mon Dec 09 11:11:11 2019 UTC +0000 action_result.data.\*.last_saved_offense_ingest_time_as_epoch | numeric | | 1575889871000 action_result.summary.last_ingested_events_ingest_time | string | | Offense ID_1=Fri Nov 29 10:05:25 2019 UTC +0000, Offense ID_3=Fri Nov 29 10:01:24 2019 UTC +0000, Offense ID_2=Fri Nov 29 10:03:18 2019 UTC +0000 action_result.summary.last_saved_offense_ingest_time | string | | Mon Dec 09 11:11:11 2019 UTC +0000 action_result.message | string | | Last saved offense ingest time: Mon Dec 09 11:11:11 2019 UTC +0000, Last ingested events ingest time: Offense ID_1=Fri Nov 29 10:05:25 2019 UTC +0000, Offense ID_3=Fri Nov 29 10:01:24 2019 UTC +0000, Offense ID_2=Fri Nov 29 10:03:18 2019 UTC +0000 summary.total_objects | numeric | | 2 summary.total_objects_successful | numeric | | 2 ## action: 'run query'
+action_result.status | string | | success failed |
+action_result.parameter.datetime | string | | 2019-12-09 11:11:11.0001 |
+action_result.parameter.offense_id | numeric | `qradar offense id` | 4 |
+action_result.parameter.operation | string | | get last saved ingestion time data |
+action_result.data.\*.last_ingested_events_ingest_time | string | | Offense ID_1=Fri Nov 29 10:05:25 2019 UTC +0000, Offense ID_3=Fri Nov 29 10:01:24 2019 UTC +0000, Offense ID_2=Fri Nov 29 10:03:18 2019 UTC +0000 |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.1 | numeric | | 1575021925702 |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.10 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.19 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.20 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.21 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.22 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.23 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.24 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.74 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.75 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.76 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.77 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.78 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.79 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.80 | numeric | | |
+action_result.data.\*.last_ingested_events_ingest_time_as_epoch.82 | numeric | | |
+action_result.data.\*.last_saved_offense_ingest_time | string | | Mon Dec 09 11:11:11 2019 UTC +0000 |
+action_result.data.\*.last_saved_offense_ingest_time_as_epoch | numeric | | 1575889871000 |
+action_result.summary.last_ingested_events_ingest_time | string | | Offense ID_1=Fri Nov 29 10:05:25 2019 UTC +0000, Offense ID_3=Fri Nov 29 10:01:24 2019 UTC +0000, Offense ID_2=Fri Nov 29 10:03:18 2019 UTC +0000 |
+action_result.summary.last_saved_offense_ingest_time | string | | Mon Dec 09 11:11:11 2019 UTC +0000 |
+action_result.message | string | | Last saved offense ingest time: Mon Dec 09 11:11:11 2019 UTC +0000, Last ingested events ingest time: Offense ID_1=Fri Nov 29 10:05:25 2019 UTC +0000, Offense ID_3=Fri Nov 29 10:01:24 2019 UTC +0000, Offense ID_2=Fri Nov 29 10:03:18 2019 UTC +0000 |
+summary.total_objects | numeric | | 2 |
+summary.total_objects_successful | numeric | | 2 |
+
+## action: 'run query'
+
 Execute an ariel query on the QRadar device
 
 Type: **investigate** \
@@ -195,13 +505,78 @@ Use this action to execute queries using AQL on the QRadar device. AQL is a well
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**query** | required | Ariel Query | string | `qradar ariel query`
+**query** | required | Ariel Query | string | `qradar ariel query` |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.query | string | `qradar ariel query` | select qid from events action_result.data.\*.events.\*.AccountDomain | string | | action_result.data.\*.events.\*.Application | string | | action_result.data.\*.events.\*.Bytes | string | | action_result.data.\*.events.\*.BytesReceived | string | | action_result.data.\*.events.\*.BytesSent | string | | action_result.data.\*.events.\*.Destination Host Name | string | | action_result.data.\*.events.\*.EventID | string | | action_result.data.\*.events.\*.File Hash | string | | action_result.data.\*.events.\*.File ID | string | | action_result.data.\*.events.\*.File Path | string | | action_result.data.\*.events.\*.Filename | string | | action_result.data.\*.events.\*.Installer Filename | string | | action_result.data.\*.events.\*.Message | string | | action_result.data.\*.events.\*.Payload | string | | action_result.data.\*.events.\*.Source Host Name | string | | action_result.data.\*.events.\*.category | numeric | | 38750003 action_result.data.\*.events.\*.categoryname_category | string | | action_result.data.\*.events.\*.destinationaddress | string | | action_result.data.\*.events.\*.destinationip | string | `ip` | 122.122.122.122 action_result.data.\*.events.\*.destinationmac | string | | action_result.data.\*.events.\*.destinationport | numeric | | 0 action_result.data.\*.events.\*.endtime | numeric | | action_result.data.\*.events.\*.eventcount | numeric | | 1 action_result.data.\*.events.\*.eventdirection | string | | action_result.data.\*.events.\*.hostname_logsourceid | string | | action_result.data.\*.events.\*.identityip | string | `ip` | 122.122.122.122 action_result.data.\*.events.\*.logsourcegroupname_logsourceid | string | | action_result.data.\*.events.\*.logsourceid | numeric | | 65 action_result.data.\*.events.\*.logsourcename_logsourceid | string | | action_result.data.\*.events.\*.magnitude | numeric | | 5 action_result.data.\*.events.\*.protocolid | numeric | | 255 action_result.data.\*.events.\*.protocolname_protocolid | string | | action_result.data.\*.events.\*.qid | numeric | | 38750003 action_result.data.\*.events.\*.qidname_qid | string | | action_result.data.\*.events.\*.queid | numeric | | action_result.data.\*.events.\*.relevance | numeric | | action_result.data.\*.events.\*.severity | numeric | | action_result.data.\*.events.\*.sourceaddress | string | | action_result.data.\*.events.\*.sourceip | string | `ip` | 122.122.122.122 action_result.data.\*.events.\*.sourcemac | string | | action_result.data.\*.events.\*.sourceport | numeric | | 0 action_result.data.\*.events.\*.starttime | numeric | | 1559907060001 action_result.data.\*.events.\*.username | string | `user name` | action_result.data.\*.flows.\*.category | numeric | | action_result.data.\*.flows.\*.destinationbytes | numeric | | action_result.data.\*.flows.\*.destinationflags | string | | action_result.data.\*.flows.\*.destinationip | string | | action_result.data.\*.flows.\*.destinationpackets | numeric | | action_result.data.\*.flows.\*.firstpackettime | numeric | | action_result.data.\*.flows.\*.flowtype | numeric | | action_result.data.\*.flows.\*.lastpackettime | numeric | | action_result.data.\*.flows.\*.protocolid | numeric | | action_result.data.\*.flows.\*.qid | numeric | | action_result.data.\*.flows.\*.sourcebytes | numeric | | action_result.data.\*.flows.\*.sourceflags | string | | action_result.data.\*.flows.\*.sourceip | string | | action_result.data.\*.flows.\*.sourcepackets | numeric | | action_result.summary | string | | action_result.message | string | | Successfully ran query summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'add listitem'
+action_result.status | string | | success failed |
+action_result.parameter.query | string | `qradar ariel query` | select qid from events |
+action_result.data.\*.events.\*.AccountDomain | string | | |
+action_result.data.\*.events.\*.Application | string | | |
+action_result.data.\*.events.\*.Bytes | string | | |
+action_result.data.\*.events.\*.BytesReceived | string | | |
+action_result.data.\*.events.\*.BytesSent | string | | |
+action_result.data.\*.events.\*.Destination Host Name | string | | |
+action_result.data.\*.events.\*.EventID | string | | |
+action_result.data.\*.events.\*.File Hash | string | | |
+action_result.data.\*.events.\*.File ID | string | | |
+action_result.data.\*.events.\*.File Path | string | | |
+action_result.data.\*.events.\*.Filename | string | | |
+action_result.data.\*.events.\*.Installer Filename | string | | |
+action_result.data.\*.events.\*.Message | string | | |
+action_result.data.\*.events.\*.Payload | string | | |
+action_result.data.\*.events.\*.Source Host Name | string | | |
+action_result.data.\*.events.\*.category | numeric | | 38750003 |
+action_result.data.\*.events.\*.categoryname_category | string | | |
+action_result.data.\*.events.\*.destinationaddress | string | | |
+action_result.data.\*.events.\*.destinationip | string | `ip` | 122.122.122.122 |
+action_result.data.\*.events.\*.destinationmac | string | | |
+action_result.data.\*.events.\*.destinationport | numeric | | 0 |
+action_result.data.\*.events.\*.endtime | numeric | | |
+action_result.data.\*.events.\*.eventcount | numeric | | 1 |
+action_result.data.\*.events.\*.eventdirection | string | | |
+action_result.data.\*.events.\*.hostname_logsourceid | string | | |
+action_result.data.\*.events.\*.identityip | string | `ip` | 122.122.122.122 |
+action_result.data.\*.events.\*.logsourcegroupname_logsourceid | string | | |
+action_result.data.\*.events.\*.logsourceid | numeric | | 65 |
+action_result.data.\*.events.\*.logsourcename_logsourceid | string | | |
+action_result.data.\*.events.\*.magnitude | numeric | | 5 |
+action_result.data.\*.events.\*.protocolid | numeric | | 255 |
+action_result.data.\*.events.\*.protocolname_protocolid | string | | |
+action_result.data.\*.events.\*.qid | numeric | | 38750003 |
+action_result.data.\*.events.\*.qidname_qid | string | | |
+action_result.data.\*.events.\*.queid | numeric | | |
+action_result.data.\*.events.\*.relevance | numeric | | |
+action_result.data.\*.events.\*.severity | numeric | | |
+action_result.data.\*.events.\*.sourceaddress | string | | |
+action_result.data.\*.events.\*.sourceip | string | `ip` | 122.122.122.122 |
+action_result.data.\*.events.\*.sourcemac | string | | |
+action_result.data.\*.events.\*.sourceport | numeric | | 0 |
+action_result.data.\*.events.\*.starttime | numeric | | 1559907060001 |
+action_result.data.\*.events.\*.username | string | `user name` | |
+action_result.data.\*.flows.\*.category | numeric | | |
+action_result.data.\*.flows.\*.destinationbytes | numeric | | |
+action_result.data.\*.flows.\*.destinationflags | string | | |
+action_result.data.\*.flows.\*.destinationip | string | | |
+action_result.data.\*.flows.\*.destinationpackets | numeric | | |
+action_result.data.\*.flows.\*.firstpackettime | numeric | | |
+action_result.data.\*.flows.\*.flowtype | numeric | | |
+action_result.data.\*.flows.\*.lastpackettime | numeric | | |
+action_result.data.\*.flows.\*.protocolid | numeric | | |
+action_result.data.\*.flows.\*.qid | numeric | | |
+action_result.data.\*.flows.\*.sourcebytes | numeric | | |
+action_result.data.\*.flows.\*.sourceflags | string | | |
+action_result.data.\*.flows.\*.sourceip | string | | |
+action_result.data.\*.flows.\*.sourcepackets | numeric | | |
+action_result.summary | string | | |
+action_result.message | string | | Successfully ran query |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'add listitem'
+
 Add an item to a reference set in QRadar
 
 Type: **generic** \
@@ -211,13 +586,30 @@ Read only: **False**
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**reference_set_name** | required | Name of reference set to add to | string | **reference_set_value** | required | Value to add to the reference set | string |
+**reference_set_name** | required | Name of reference set to add to | string | |
+**reference_set_value** | required | Value to add to the reference set | string | |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.reference_set_name | string | | Demo action_result.parameter.reference_set_value | string | | 122.122.122.122 action_result.data.\*.creation_time | numeric | | 1558518483009 action_result.data.\*.element_type | string | | IP action_result.data.\*.name | string | | Demo action_result.data.\*.number_of_elements | numeric | | 3 action_result.data.\*.timeout_type | string | | FIRST_SEEN action_result.summary.element_type | string | | IP action_result.summary.name | string | | Demo action_result.summary.number_of_elements | numeric | | 3 action_result.message | string | | Element type: IP, Name: Demo, Number of elements: 3 summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'close offense'
+action_result.status | string | | success failed |
+action_result.parameter.reference_set_name | string | | Demo |
+action_result.parameter.reference_set_value | string | | 122.122.122.122 |
+action_result.data.\*.creation_time | numeric | | 1558518483009 |
+action_result.data.\*.element_type | string | | IP |
+action_result.data.\*.name | string | | Demo |
+action_result.data.\*.number_of_elements | numeric | | 3 |
+action_result.data.\*.timeout_type | string | | FIRST_SEEN |
+action_result.summary.element_type | string | | IP |
+action_result.summary.name | string | | Demo |
+action_result.summary.number_of_elements | numeric | | 3 |
+action_result.message | string | | Element type: IP, Name: Demo, Number of elements: 3 |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'close offense'
+
 Close an active offense, marking status=CLOSED
 
 Type: **generic** \
@@ -227,17 +619,62 @@ Read only: **False**
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**offense_id** | required | Offense ID to close | numeric | `qradar offense id` **closing_reason_id** | required | Reason for closing offense | numeric | `qradar offense closing reason id`
+**offense_id** | required | Offense ID to close | numeric | `qradar offense id` |
+**closing_reason_id** | required | Reason for closing offense | numeric | `qradar offense closing reason id` |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.closing_reason_id | numeric | `qradar offense closing reason id` | 1 action_result.parameter.offense_id | numeric | `qradar offense id` | 41 action_result.data.\*.assigned_to | string | | admin action_result.data.\*.categories | string | | Error action_result.data.\*.category_count | numeric | | 4 action_result.data.\*.close_time | numeric | | 1559905203000 action_result.data.\*.closing_reason_id | numeric | `qradar offense closing reason id` | 1 action_result.data.\*.closing_user | string | | API_token: Phantom action_result.data.\*.credibility | numeric | | 4 action_result.data.\*.description | string | | Anomaly: Access to Test or Test Defined Address
-preceded by Communication with Known Watched Networks
-action_result.data.\*.destination_networks | string | | other action_result.data.\*.device_count | numeric | | 3 action_result.data.\*.domain_id | numeric | | action_result.data.\*.event_count | numeric | | 2660 action_result.data.\*.flow_count | numeric | | 0 action_result.data.\*.follow_up | boolean | | False True action_result.data.\*.id | numeric | `qradar offense id` | 41 action_result.data.\*.inactive | boolean | | False True action_result.data.\*.last_updated_time | numeric | | 1557829383413 action_result.data.\*.local_destination_count | numeric | | 0 action_result.data.\*.magnitude | numeric | | 3 action_result.data.\*.offense_source | string | `ip` | 122.122.122.122 action_result.data.\*.offense_type | numeric | | 0 action_result.data.\*.policy_category_count | numeric | | 0 action_result.data.\*.protected | boolean | | False True action_result.data.\*.relevance | numeric | | 2 action_result.data.\*.remote_destination_count | numeric | | 1 action_result.data.\*.rules.\*.id | numeric | | action_result.data.\*.rules.\*.type | string | | action_result.data.\*.security_category_count | numeric | | 4 action_result.data.\*.severity | numeric | | 7 action_result.data.\*.source_count | numeric | | 1 action_result.data.\*.source_network | string | | other action_result.data.\*.start_time | numeric | | 1554413327061 action_result.data.\*.status | string | | CLOSED action_result.data.\*.username_count | numeric | `user name` | 0 action_result.summary.flow_count | numeric | | 0 action_result.summary.name | string | | Anomaly: Access to Test or Test Defined Address
-preceded by Communication with Known Watched Networks action_result.summary.source | string | `ip` | 122.122.122.122 action_result.summary.start_time | string | | 2019-04-04 21:28:47 UTC action_result.summary.status | string | | CLOSED action_result.summary.update_time | string | | 2019-05-14 10:23:03 UTC action_result.message | string | | Status: CLOSED, Source: 122.122.122.122, Update time: 2019-05-14 10:23:03 UTC, Name: Anomaly: Access to Test or Test Defined Address
-preceded by Communication with Known Watched Networks, Flow count: 0, Start time: 2019-04-04 21:28:47 UTC summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'update offense'
+action_result.status | string | | success failed |
+action_result.parameter.closing_reason_id | numeric | `qradar offense closing reason id` | 1 |
+action_result.parameter.offense_id | numeric | `qradar offense id` | 41 |
+action_result.data.\*.assigned_to | string | | admin |
+action_result.data.\*.categories | string | | Error |
+action_result.data.\*.category_count | numeric | | 4 |
+action_result.data.\*.close_time | numeric | | 1559905203000 |
+action_result.data.\*.closing_reason_id | numeric | `qradar offense closing reason id` | 1 |
+action_result.data.\*.closing_user | string | | API_token: Phantom |
+action_result.data.\*.credibility | numeric | | 4 |
+action_result.data.\*.description | string | | Anomaly: Access to Test or Test Defined Address preceded by Communication with Known Watched Networks |
+action_result.data.\*.destination_networks | string | | other |
+action_result.data.\*.device_count | numeric | | 3 |
+action_result.data.\*.domain_id | numeric | | |
+action_result.data.\*.event_count | numeric | | 2660 |
+action_result.data.\*.flow_count | numeric | | 0 |
+action_result.data.\*.follow_up | boolean | | False True |
+action_result.data.\*.id | numeric | `qradar offense id` | 41 |
+action_result.data.\*.inactive | boolean | | False True |
+action_result.data.\*.last_updated_time | numeric | | 1557829383413 |
+action_result.data.\*.local_destination_count | numeric | | 0 |
+action_result.data.\*.magnitude | numeric | | 3 |
+action_result.data.\*.offense_source | string | `ip` | 122.122.122.122 |
+action_result.data.\*.offense_type | numeric | | 0 |
+action_result.data.\*.policy_category_count | numeric | | 0 |
+action_result.data.\*.protected | boolean | | False True |
+action_result.data.\*.relevance | numeric | | 2 |
+action_result.data.\*.remote_destination_count | numeric | | 1 |
+action_result.data.\*.rules.\*.id | numeric | | |
+action_result.data.\*.rules.\*.type | string | | |
+action_result.data.\*.security_category_count | numeric | | 4 |
+action_result.data.\*.severity | numeric | | 7 |
+action_result.data.\*.source_count | numeric | | 1 |
+action_result.data.\*.source_network | string | | other |
+action_result.data.\*.start_time | numeric | | 1554413327061 |
+action_result.data.\*.status | string | | CLOSED |
+action_result.data.\*.username_count | numeric | `user name` | 0 |
+action_result.summary.flow_count | numeric | | 0 |
+action_result.summary.name | string | | Anomaly: Access to Test or Test Defined Address preceded by Communication with Known Watched Networks |
+action_result.summary.source | string | `ip` | 122.122.122.122 |
+action_result.summary.start_time | string | | 2019-04-04 21:28:47 UTC |
+action_result.summary.status | string | | CLOSED |
+action_result.summary.update_time | string | | 2019-05-14 10:23:03 UTC |
+action_result.message | string | | Status: CLOSED, Source: 122.122.122.122, Update time: 2019-05-14 10:23:03 UTC, Name: Anomaly: Access to Test or Test Defined Address preceded by Communication with Known Watched Networks, Flow count: 0, Start time: 2019-04-04 21:28:47 UTC |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'update offense'
+
 Attach a note to an offense
 
 Type: **generic** \
@@ -247,13 +684,24 @@ Read only: **False**
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**offense_id** | required | Offense ID to attach note to | numeric | `qradar offense id` **note_text** | required | Text to put into note | string |
+**offense_id** | required | Offense ID to attach note to | numeric | `qradar offense id` |
+**note_text** | required | Text to put into note | string | |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.note_text | string | | Note Added By Phantom action_result.parameter.offense_id | numeric | `qradar offense id` | 41 action_result.data | string | | action_result.summary | string | | action_result.message | string | | Successfully added note to offense summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'assign user'
+action_result.status | string | | success failed |
+action_result.parameter.note_text | string | | Note Added By Phantom |
+action_result.parameter.offense_id | numeric | `qradar offense id` | 41 |
+action_result.data | string | | |
+action_result.summary | string | | |
+action_result.message | string | | Successfully added note to offense |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'assign user'
+
 Assign the user to an offense
 
 Type: **generic** \
@@ -263,13 +711,24 @@ Read only: **False**
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**offense_id** | required | Offense ID to assign the user to | numeric | `qradar offense id` **assignee** | required | Name of the user | string |
+**offense_id** | required | Offense ID to assign the user to | numeric | `qradar offense id` |
+**assignee** | required | Name of the user | string | |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.assignee | string | | admin action_result.parameter.offense_id | numeric | `qradar offense id` | 41 action_result.data | string | | action_result.summary | string | | action_result.message | string | | Successfully assigned user to offense summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'get rule info'
+action_result.status | string | | success failed |
+action_result.parameter.assignee | string | | admin |
+action_result.parameter.offense_id | numeric | `qradar offense id` | 41 |
+action_result.data | string | | |
+action_result.summary | string | | |
+action_result.message | string | | Successfully assigned user to offense |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'get rule info'
+
 Retrieve QRadar rule information
 
 Type: **investigate** \
@@ -279,13 +738,36 @@ Read only: **True**
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**rule_id** | required | Rule ID for which information needs to be extracted | numeric | `qradar rule id`
+**rule_id** | required | Rule ID for which information needs to be extracted | numeric | `qradar rule id` |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.rule_id | numeric | `qradar rule id` | 1421 action_result.data.\*.average_capacity | numeric | | 3541750 action_result.data.\*.base_capacity | numeric | | 3541750 action_result.data.\*.base_host_id | numeric | | 384 action_result.data.\*.capacity_timestamp | numeric | | 1566896735557 action_result.data.\*.creation_date | numeric | | 1155662266056 action_result.data.\*.enabled | boolean | | True False action_result.data.\*.id | numeric | | 1421 action_result.data.\*.identifier | string | | SYSTEM-1421 action_result.data.\*.linked_rule_identifier | string | | action_result.data.\*.modification_date | numeric | | 1267729985038 action_result.data.\*.name | string | | User:BB:FalsePositives: User Defined Server Type 2 False Positive Categories action_result.data.\*.origin | string | | SYSTEM action_result.data.\*.owner | string | | admin action_result.data.\*.type | string | | EVENT action_result.summary.id | numeric | | 1421 action_result.summary.name | string | | User:BB:FalsePositives: User Defined Server Type 2 False Positive Categories action_result.message | string | | Id: 1421, Name: User:BB:FalsePositives: User Defined Server Type 2 False Positive Categories summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'list rules'
+action_result.status | string | | success failed |
+action_result.parameter.rule_id | numeric | `qradar rule id` | 1421 |
+action_result.data.\*.average_capacity | numeric | | 3541750 |
+action_result.data.\*.base_capacity | numeric | | 3541750 |
+action_result.data.\*.base_host_id | numeric | | 384 |
+action_result.data.\*.capacity_timestamp | numeric | | 1566896735557 |
+action_result.data.\*.creation_date | numeric | | 1155662266056 |
+action_result.data.\*.enabled | boolean | | True False |
+action_result.data.\*.id | numeric | | 1421 |
+action_result.data.\*.identifier | string | | SYSTEM-1421 |
+action_result.data.\*.linked_rule_identifier | string | | |
+action_result.data.\*.modification_date | numeric | | 1267729985038 |
+action_result.data.\*.name | string | | User:BB:FalsePositives: User Defined Server Type 2 False Positive Categories |
+action_result.data.\*.origin | string | | SYSTEM |
+action_result.data.\*.owner | string | | admin |
+action_result.data.\*.type | string | | EVENT |
+action_result.summary.id | numeric | | 1421 |
+action_result.summary.name | string | | User:BB:FalsePositives: User Defined Server Type 2 False Positive Categories |
+action_result.message | string | | Id: 1421, Name: User:BB:FalsePositives: User Defined Server Type 2 False Positive Categories |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'list rules'
+
 List all QRadar rules
 
 Type: **investigate** \
@@ -295,13 +777,35 @@ Read only: **True**
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**count** | optional | Number of rules to retrieve | numeric |
+**count** | optional | Number of rules to retrieve | numeric | |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed action_result.parameter.count | numeric | | 31 action_result.data.\*.average_capacity | numeric | | 3541750 action_result.data.\*.base_capacity | numeric | | 3541750 action_result.data.\*.base_host_id | numeric | | 384 action_result.data.\*.capacity_timestamp | numeric | | 1566896735557 action_result.data.\*.creation_date | numeric | | 1155662266056 action_result.data.\*.enabled | boolean | | True False action_result.data.\*.id | numeric | `qradar rule id` | 1421 action_result.data.\*.identifier | string | | SYSTEM-1421 action_result.data.\*.linked_rule_identifier | string | | action_result.data.\*.modification_date | numeric | | 1267729985038 action_result.data.\*.name | string | | User:BB:FalsePositives: User Defined Server Type 2 False Positive Categories action_result.data.\*.origin | string | | SYSTEM action_result.data.\*.owner | string | | admin action_result.data.\*.type | string | | EVENT action_result.summary.total_rules | numeric | | 135 action_result.message | string | | Total rules: 135 summary.total_objects | numeric | | 1 summary.total_objects_successful | numeric | | 1 ## action: 'on poll'
+action_result.status | string | | success failed |
+action_result.parameter.count | numeric | | 31 |
+action_result.data.\*.average_capacity | numeric | | 3541750 |
+action_result.data.\*.base_capacity | numeric | | 3541750 |
+action_result.data.\*.base_host_id | numeric | | 384 |
+action_result.data.\*.capacity_timestamp | numeric | | 1566896735557 |
+action_result.data.\*.creation_date | numeric | | 1155662266056 |
+action_result.data.\*.enabled | boolean | | True False |
+action_result.data.\*.id | numeric | `qradar rule id` | 1421 |
+action_result.data.\*.identifier | string | | SYSTEM-1421 |
+action_result.data.\*.linked_rule_identifier | string | | |
+action_result.data.\*.modification_date | numeric | | 1267729985038 |
+action_result.data.\*.name | string | | User:BB:FalsePositives: User Defined Server Type 2 False Positive Categories |
+action_result.data.\*.origin | string | | SYSTEM |
+action_result.data.\*.owner | string | | admin |
+action_result.data.\*.type | string | | EVENT |
+action_result.summary.total_rules | numeric | | 135 |
+action_result.message | string | | Total rules: 135 |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'on poll'
+
 Callback action for the on_poll ingest functionality
 
 Type: **ingest** \
@@ -313,7 +817,11 @@ The default start_time is the past 5 days. The default end_time is now.
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**container_id** | optional | Parameter ignored for this app | string | **start_time** | optional | Start of time range, in epoch time (milliseconds) | numeric | **end_time** | optional | End of time range, in epoch time (milliseconds) | numeric | **container_count** | optional | Maximum number of container records to query for | numeric | **artifact_count** | optional | Parameter ignored for this app | numeric |
+**container_id** | optional | Parameter ignored for this app | string | |
+**start_time** | optional | Start of time range, in epoch time (milliseconds) | numeric | |
+**end_time** | optional | End of time range, in epoch time (milliseconds) | numeric | |
+**container_count** | optional | Maximum number of container records to query for | numeric | |
+**artifact_count** | optional | Parameter ignored for this app | numeric | |
 
 #### Action Output
 

--- a/github-actions/start-release/tests/test_build_docs.py
+++ b/github-actions/start-release/tests/test_build_docs.py
@@ -3,6 +3,7 @@ import itertools
 import logging
 import os
 import shutil
+import textwrap
 
 import pytest
 
@@ -55,8 +56,13 @@ def test_build_docs(app_dir: Path, expected_new_files: list[str]):
             # Catch the auto-generated copyright year
             expected_line = expected_line.replace("{{year}}", str(year))
 
-            assert actual_line == expected_line, (
-                f"Line {num} differed from {expected_readme}:\n{actual_line=}\n{expected_line=}\n"
+            assert actual_line == expected_line, textwrap.dedent(
+                f"""
+                Line {num} differed from {expected_readme}:
+                  {actual_line=}
+                {expected_line=}
+
+                """
             )
 
     for expected_new_file in expected_new_files:


### PR DESCRIPTION
Fixing a few minor issues in table rendering:
- We were not properly creating newlines between table rows, which would lead to the rendered markdown losing everything past each action's first parameter or output. I fixed this in part by adding a trailing ` |` to each table line, which is optional in Markdown but helps the engine better understand rows whose final column is empty
- The heading for the next action after an output table would not have a newline in front of it, again leading to its loss
- When an action's output object was empty, we would actually break the output table with a double newline
- Fixed handling of example values which ended with newlines by trimming them
- Fixed handling of example values which contained newlines by replacing them with spaces