### PR TITLE
fix(start-release): Fix compatibility issue with urllib3 2.0

### DIFF
--- a/github-actions/start-release/api/github.py
+++ b/github-actions/start-release/api/github.py
@@ -35,7 +35,7 @@ class GitHubApiSession:
                 HTTPStatus.SERVICE_UNAVAILABLE,
                 HTTPStatus.GATEWAY_TIMEOUT,
             ],
-            method_whitelist=["GET", "PATCH", "POST"],
+            allowed_methods=["GET", "PATCH", "POST"],
         )
         self._session.mount(self._repo_base_url, HTTPAdapter(max_retries=retry_strategy))
 


### PR DESCRIPTION
Move from deprecated 'method_whitelist' arg to 'allowed_methods' in Retry policy