### PR TITLE
PAPP-35418: Adding conventional commits to pre-commit

### DIFF
--- a/templates/pre-commit-hooks-template.yaml
+++ b/templates/pre-commit-hooks-template.yaml
@@ -3,6 +3,12 @@
 
 # This is a template for connector pre-commit hooks
 repos:
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.0.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:


### PR DESCRIPTION
Caught commit not following conventional commits format:
<img width="1347" alt="Screenshot 2025-02-25 at 10 52 02 AM" src="https://github.com/user-attachments/assets/585d002a-7bec-4c34-b2ef-af310a10419a" />

Commit follow conventional commits format:
<img width="1345" alt="Screenshot 2025-02-25 at 10 53 21 AM" src="https://github.com/user-attachments/assets/69445b0c-8f51-4a4d-a895-c04db88342d8" />

