### PR TITLE
maint: Fix get opt params

### DIFF
--- a/pre-commit/tests/data/static_tests/app_dir/statictests.json
+++ b/pre-commit/tests/data/static_tests/app_dir/statictests.json
@@ -37,6 +37,11 @@
                 "IN"
             ],
             "order": 1
+        },
+        "domain": {
+            "description": "Domain for the FMC",
+            "data_type": "string",
+            "order": 2
         }
     },
     "actions": [

--- a/pre-commit/tests/data/static_tests/app_dir/statictests_connector.py
+++ b/pre-commit/tests/data/static_tests/app_dir/statictests_connector.py
@@ -79,7 +79,8 @@ class FP_Connector(BaseConnector):
             self.debug_print(STATE_FILE_CORRUPT_ERR)
             self._reset_state_file()
 
-        ret_val = self.authenicate_cloud_fmc(config)
+        if "region" in config and "api_key" in config.keys() and config.get("domain"):
+            ret_val = self.authenicate_cloud_fmc(config)
 
         if phantom.is_fail(ret_val):
             return self.get_status()
@@ -93,9 +94,16 @@ class FP_Connector(BaseConnector):
         """
         region = config["region"]
         api_key = config["api_key"]
-        self.firepower_host = CLOUD_HOST.format(region=region.lower())
+        domain = config["domain"]
+        self.another(config)
+
+        self.firepower_host = CLOUD_HOST.format(region=region.lower(), domain=domain)
         self.headers.update({"Authorization": f"Bearer {api_key}"})
         return phantom.APP_SUCCESS
+
+    def another(self, config):
+        region = config["region"]
+        self.debug_print(region)
 
     def _process_empty_response(self, response, action_result) -> RetVal:
         if response.status_code == 200:

--- a/pre-commit/tests/data/static_tests/expected/statictests.json
+++ b/pre-commit/tests/data/static_tests/expected/statictests.json
@@ -37,6 +37,11 @@
                 "IN"
             ],
             "order": 1
+        },
+        "domain": {
+            "description": "Domain for the FMC",
+            "data_type": "string",
+            "order": 2
         }
     },
     "actions": [


### PR DESCRIPTION
- Changed approach to override ast.NodeVisitor class to be able to track "safe keys" in a given context. Safe keys refer to keys that are explicitly checked to be in a dictionary through either "key in dict", "key in dict.keys()", "dict.get("key") is not None" and "dict.get(key)"
- Previously it was only assumed that the config dict was used only in the initialize function and the variable assigned to this dict was always called config. However, neither of these things are true. We are now keeping track of all dictionaries that may lead to unsafe gets in `dict_id` which is now a dictionary representing {unsafe_dic_name: unsafe_dic_params}. Also, we're explicitly searching for an assignment that involves self.get_config() and extracting the lhs to get the variable name representing the configs dictionary
- We're also now keeping track of functions visited to make sure duplicate unsafe entries aren't outputted

Crowdstrike static test pass: https://github.com/splunk-soar-connectors/crowdstrikeoauth/actions/runs/13575074587/job/37949243266

Also tested with a more complex case in frictionless_connectors that is the same as the sample connector in json_tests/app_dir. The test case checked that multiple keys were present using various methods within a context that involved several function calls that passed config as a param. So it started with this line `if "region" in config and "api_key" in config.keys() and config.get("domain"):` which then passes the config dic to `authenicate_cloud_fmc`, which then passes the config dic to `another`. The test results are shown in the screenshot. Note the failures are not related and are due to unsafe gets in `_handle_list_network_objects`
<img width="1352" alt="Screenshot 2025-02-27 at 12 30 46 PM" src="https://github.com/user-attachments/assets/912e28c9-fd33-41c4-ae96-31662f1cbacc" />
