### PR TITLE
PAPP-35560: Release notes check to pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -16,6 +16,12 @@
   entry: pre-commit/package_app_dependencies.sh
   language: script
   files: '^requirements.txt$'
+- id: release-notes
+  name: update release notes
+  description: Updates release notes for connector
+  language: script
+  entry: pre-commit/release_notes.sh
+  pass_filenames: false
 - id: static-tests
   name: Run static tests
   description: Runs tests to validate app json, check code correctness, and detect security vulnerabilities

--- a/pre-commit/release_notes.py
+++ b/pre-commit/release_notes.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+import re
+
+UNRELEASED_MD_HEADER = "**Unreleased**"
+RELEASE_NOTE_PATTERN = re.compile(r"^\s*\* (?P<note>.+)$")
+# The minimum number of white spaces a nested list entry needs to be
+# indented from its parent for it be rendered correctly on GitHub
+MD_NESTED_LIST_MIN_INDENT = 2
+
+# The maximum number of white spaces a nested list entry can be
+# indented from its parent for it to be rendered correctly on GitHub
+MD_NESTED_LIST_MAX_INDENT = 5
+
+
+def check_release_notes(app_directory: str):
+    release_notes_path = Path(app_directory) / "release_notes/unreleased.md"
+    print(f"path to release notes {release_notes_path}")
+    if not release_notes_path.exists():
+        print(
+            "Release notes file does not exist. Creating it now. This hook will still fail because it needs to be populated."
+        )
+        release_notes_path.write_text(UNRELEASED_MD_HEADER + "\n")
+        raise ValueError("Release notes file is empty. Please populate it with release notes.")
+
+    release_notes = release_notes_path.read_text().rstrip().splitlines()
+    length = len(release_notes)
+    print(f"release notes are {release_notes} with lentgh {length}")
+    if not release_notes:
+        release_notes_path.write_text(UNRELEASED_MD_HEADER + "\n")
+        raise ValueError("Release notes file is empty. Please populate it with release notes.")
+
+    incorrect_format = False
+
+    if release_notes[0] != UNRELEASED_MD_HEADER:
+        # assuming that the first line is a note
+        release_notes.insert(0, UNRELEASED_MD_HEADER)
+
+    parent_depths = []
+    for i in range(1, len(release_notes)):
+        note = release_notes[i]
+        if not note or not note.strip():
+            continue
+
+        match = RELEASE_NOTE_PATTERN.match(note)
+        if not match:
+            leading_whitespace = re.match(r"^\s*", note).group()
+            new_note = f"{leading_whitespace}* {note.strip()}"
+            if not (
+                match := RELEASE_NOTE_PATTERN.match(new_note)
+            ):  # check if the note is still incorrect
+                # fix any successfully caught errors found before
+                if incorrect_format:
+                    release_notes_path.write_text("\n".join(release_notes) + "\n")
+                raise ValueError(
+                    f"Detected incorrectly formatted release note: '{note}'. Tried fixing but failed."
+                )
+            else:
+                incorrect_format = True
+                release_notes[i] = new_note
+                print(f"Fixed release note formatting for {note}.")
+
+        note = match.group()
+        cur_depth, parent_depth = note.index("*"), parent_depths[-1] if parent_depths else 0
+        depth_diff = cur_depth - parent_depth
+        # Previous nested list ended and we're moving back up one or more levels
+        if depth_diff < 0:
+            while True:
+                parent_depths.pop()
+                depth_diff = cur_depth - parent_depths[-1] if parent_depths else 0
+                if depth_diff >= 0:
+                    break
+        # Current note is too far indented from its parent
+        elif depth_diff > MD_NESTED_LIST_MAX_INDENT:
+            incorrect_format = True
+            new_depth = parent_depth + MD_NESTED_LIST_MAX_INDENT - 1
+            note = " " * new_depth + note.lstrip()
+            release_notes[i] = note
+            print(f"Fixed indentation for {note}.")
+        # Current note starts a new nested list - record the depth of the new list
+        elif MD_NESTED_LIST_MIN_INDENT <= depth_diff:
+            parent_depths.append(cur_depth)
+        # Current note is on the same level as the previous
+        else:
+            pass
+
+    # fix errors if any were found
+    if incorrect_format:
+        release_notes_path.write_text("\n".join(release_notes) + "\n")
+        print("Release notes file has been updated with corrected formatting.")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("directory")
+
+    args = parser.parse_args()
+    print("calling release notes")
+    exit(check_release_notes(args.directory))

--- a/pre-commit/release_notes.py
+++ b/pre-commit/release_notes.py
@@ -14,7 +14,6 @@ MD_NESTED_LIST_MAX_INDENT = 5
 
 def check_release_notes(app_directory: str):
     release_notes_path = Path(app_directory) / "release_notes/unreleased.md"
-    print(f"path to release notes {release_notes_path}")
     if not release_notes_path.exists():
         print(
             "Release notes file does not exist. Creating it now. This hook will still fail because it needs to be populated."
@@ -23,8 +22,6 @@ def check_release_notes(app_directory: str):
         raise ValueError("Release notes file is empty. Please populate it with release notes.")
 
     release_notes = release_notes_path.read_text().rstrip().splitlines()
-    length = len(release_notes)
-    print(f"release notes are {release_notes} with lentgh {length}")
     if not release_notes:
         release_notes_path.write_text(UNRELEASED_MD_HEADER + "\n")
         raise ValueError("Release notes file is empty. Please populate it with release notes.")
@@ -96,5 +93,4 @@ if __name__ == "__main__":
     parser.add_argument("directory")
 
     args = parser.parse_args()
-    print("calling release notes")
     exit(check_release_notes(args.directory))

--- a/pre-commit/release_notes.sh
+++ b/pre-commit/release_notes.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR=$(pwd)
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+IN_DOCKER=false
+
+# Use to see if in container
+if /opt/python/cp39-cp39/bin/python --version &>/dev/null; then
+	IN_DOCKER=true
+fi
+
+if [ "$IN_DOCKER" = true ]; then
+	/opt/python/cp39-cp39/bin/python "$SCRIPT_DIR"/release_notes.py .
+	exit $?
+fi
+
+# Not in container, proceed with Docker setup
+IMAGE="quay.io/pypa/manylinux_2_28_x86_64"
+DOCKERFILE=""
+
+while getopts 'i:d:' flag; do
+	case "${flag}" in
+	i) IMAGE="${OPTARG}" ;;
+	d) DOCKERFILE="${OPTARG}" ;;
+	*) echo "Invalid flag ${OPTARG}" && exit 1 ;;
+	esac
+done
+
+function prepare_docker_image() {
+	if [[ $DOCKERFILE != "" ]]; then
+		local appdir_base
+		local appdir_dir
+
+		appdir_base=$(basename "$APP_DIR")
+		appdir_dir=$(dirname "$APP_DIR")
+		IMAGE=$(basename "$appdir_dir")/"$appdir_base"
+
+		echo "Creating image from context $DOCKERFILE, tag: $IMAGE"
+		docker build -t "$IMAGE" -f "$DOCKERFILE" "$APP_DIR"
+	fi
+	echo "Using image: $IMAGE"
+}
+
+if ! docker info &>/dev/null; then
+	echo 'Please ensure Docker is installed and running on your machine'
+	exit 1
+fi
+
+prepare_docker_image
+docker run --rm -v "$APP_DIR":/src -v "$SCRIPT_DIR":/pre-commit/ -w /src \
+	"$IMAGE" /bin/bash -c \
+	"/opt/python/cp39-cp39/bin/python /pre-commit/release_notes.py ."

--- a/pre-commit/static_tests.sh
+++ b/pre-commit/static_tests.sh
@@ -25,7 +25,7 @@ else
 fi
 
 if [ "$IN_DOCKER" = true ]; then
-	/opt/python/cp39-cp39/bin/pip install jsonschema lxml
+	/opt/python/cp39-cp39/bin/pip install jsonschema lxml 'django<5'
 	/opt/python/cp39-cp39/bin/python "$SCRIPT_DIR"/static_tests.py "$test_mode" . --app-repo-name "$(basename "$APP_DIR")"
 	exit $?
 fi

--- a/pre-commit/tests/data/release_notes/release_notes_failing/actual/release_notes/unreleased.md
+++ b/pre-commit/tests/data/release_notes/release_notes_failing/actual/release_notes/unreleased.md
@@ -1,0 +1,3 @@
+* test failing.
+            bad tab and format
+    bad format

--- a/pre-commit/tests/data/release_notes/release_notes_failing/expected/release_notes/unreleased.md
+++ b/pre-commit/tests/data/release_notes/release_notes_failing/expected/release_notes/unreleased.md
@@ -1,0 +1,4 @@
+**Unreleased**
+* test failing.
+    * bad tab and format
+    * bad format

--- a/pre-commit/tests/data/release_notes/release_notes_passing/release_notes/unreleased.md
+++ b/pre-commit/tests/data/release_notes/release_notes_passing/release_notes/unreleased.md
@@ -1,0 +1,4 @@
+**Unreleased**
+
+* [test] test release note.
+    * test

--- a/pre-commit/tests/test_release_notes.py
+++ b/pre-commit/tests/test_release_notes.py
@@ -1,0 +1,67 @@
+import logging
+import os
+import shutil
+import subprocess
+
+import pytest
+from pathlib import Path
+
+PRE_COMMIT_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+
+logging.getLogger().setLevel(logging.INFO)
+
+
+@pytest.fixture(scope="function")
+def app_dir(request: pytest.FixtureRequest) -> Path:
+    app_dir = Path(request.param)  # type: ignore
+    app_dir_copy = Path(f"{app_dir}_copy")
+
+    shutil.copytree(app_dir, app_dir_copy)
+
+    def remove_test_dir_copy():
+        shutil.rmtree(app_dir_copy, ignore_errors=True)
+
+    request.addfinalizer(remove_test_dir_copy)
+
+    return app_dir_copy
+
+
+@pytest.mark.parametrize(
+    "app_dir",
+    ["tests/data/release_notes/release_notes_passing"],
+    indirect=["app_dir"],
+)
+def test_release_notes_passing(app_dir: Path):
+    result = subprocess.run(
+        [os.path.join(PRE_COMMIT_DIR, "release_notes.sh")],
+        cwd=app_dir,
+        capture_output=True,
+    )
+    print(result.stderr.decode())
+    assert result.returncode == 0
+
+
+@pytest.mark.parametrize(
+    "app_dir",
+    ["tests/data/release_notes/release_notes_failing/actual"],
+    indirect=["app_dir"],
+)
+def test_release_notes_failing(app_dir: Path):
+    expected_dir = Path("tests/data/release_notes/release_notes_failing/expected")
+    expected_file = "release_notes/unreleased.md"
+
+    result = subprocess.run(
+        [os.path.join(PRE_COMMIT_DIR, "release_notes.sh")],
+        cwd=app_dir,
+        capture_output=True,
+    )
+    assert result.returncode == 0
+
+    actual_path = app_dir / expected_file
+    expected_path = expected_dir / expected_file
+
+    assert actual_path.exists(), f"Missing expected file {expected_file}"
+    print(actual_path.read_text())
+    assert actual_path.read_text() == expected_path.read_text(), (
+        f"Release note file {expected_file} did not match expectations!"
+    )

--- a/templates/pre-commit-hooks-template.yaml
+++ b/templates/pre-commit-hooks-template.yaml
@@ -54,4 +54,5 @@ repos:
       - id: build-docs
       - id: copyright
       - id: package-app-dependencies
+      - id: release-notes
       - id: static-tests


### PR DESCRIPTION
- Adding release_note format check
- Release notes are fixed when possible for incorrect header, unformatted notes and notes with too many tabs

Failing release notes check: https://github.com/splunk-soar-connectors/frictionless_connectors_test/actions/runs/13666883109/job/38209817674

Passing release notes check: https://github.com/splunk-soar-connectors/frictionless_connectors_test/actions/runs/13666941888/job/38209977405
 