### PR TITLE
fix(id): revert change which lowercased the censys app ID

### DIFF
--- a/local_hooks/data/appid_to_name.json
+++ b/local_hooks/data/appid_to_name.json
@@ -295,7 +295,7 @@
     "95e3bcff-bfca-454d-b59e-768da6280c38": "REST Data Source",
     "963c802e-8b8c-46d8-bd45-28e6c455f51e": "IronNet",
     "96f3e021-5396-42d0-97f4-4fab683e9adb": "Cisco Umbrella",
-    "97c8df6f-c870-4482-b6ca-b6c31745fbab": "Censys",
+    "97C8DF6F-C870-4482-B6CA-B6C31745FBAB": "Censys",
     "9a810074-0261-4c91-99d4-7ed782ee12a8": "Cofense Vision",
     "9b08d390-545e-4a68-b820-84d38dc40590": "RiskSense",
     "9b4ee392-1a84-41ff-9e47-547f7740cece": "CriticalStack Intel",

--- a/local_hooks/data/appid_to_package_name.json
+++ b/local_hooks/data/appid_to_package_name.json
@@ -291,7 +291,7 @@
     "95e3bcff-bfca-454d-b59e-768da6280c38": "phantom_restingest",
     "963c802e-8b8c-46d8-bd45-28e6c455f51e": "phantom_ironnet",
     "96f3e021-5396-42d0-97f4-4fab683e9adb": "phantom_ciscoumbrella",
-    "97c8df6f-c870-4482-b6ca-b6c31745fbab": "phantom_censys",
+    "97C8DF6F-C870-4482-B6CA-B6C31745FBAB": "phantom_censys",
     "9a810074-0261-4c91-99d4-7ed782ee12a8": "phantom_cofensevision",
     "9b08d390-545e-4a68-b820-84d38dc40590": "phantom_risksense",
     "9b4ee392-1a84-41ff-9e47-547f7740cece": "phantom_criticalstack",


### PR DESCRIPTION
The Censys app had an uppercase app GUID, and as part of our recent efforts to standardize CI, we lowercased it. That's actually problematic because it's in essence a whole new GUID, which leads SOAR instances to end up installing two Censys apps