### PR TITLE
PAPP-37635: onboard new app - doppel

### DIFF
--- a/local_hooks/data/appid_to_name.json
+++ b/local_hooks/data/appid_to_name.json
@@ -276,6 +276,7 @@
   "86fd2d88-1b9c-4dbb-b6aa-1fec6f771c0f": "DigiCert",
   "87078d70-ca1e-4dfa-9dbe-cf3fa56b99ae": "ipstack",
   "876ab991-313e-48e7-bccd-e8c9650c239c": "DNS",
+  "88e88f59-5c78-457b-9d81-1f41f9fd2096": "Doppel",
   "8925dbb5-abe1-4e5d-b053-326e35e1e194": "Chronicle",
   "897890aa-14f5-4d6c-b68c-e557ff30d251": "FireAMP",
   "89cf5316-a44d-4037-a07e-5f7504528044": "Varonis SaaS for SOAR",

--- a/local_hooks/data/appid_to_package_name.json
+++ b/local_hooks/data/appid_to_package_name.json
@@ -274,6 +274,7 @@
   "86fd2d88-1b9c-4dbb-b6aa-1fec6f771c0f": "phantom_digicert",
   "87078d70-ca1e-4dfa-9dbe-cf3fa56b99ae": "phantom_ipstack",
   "876ab991-313e-48e7-bccd-e8c9650c239c": "phantom_dns",
+  "88e88f59-5c78-457b-9d81-1f41f9fd2096": "phantom_doppel",
   "8925dbb5-abe1-4e5d-b053-326e35e1e194": "phantom_chronicle",
   "897890aa-14f5-4d6c-b68c-e557ff30d251": "phantom_fireamp",
   "89cf5316-a44d-4037-a07e-5f7504528044": "phantom_varonissaas",


### PR DESCRIPTION
PAPP-37635: onboard new unsupported app - https://github.com/splunk-soar-connectors/doppel/pull/1