### PR TITLE
fix: isolate container pip from host `pythonpath` in package-app-dependencies hook

### DIFF
--- a/local_hooks/package_app_dependencies.py
+++ b/local_hooks/package_app_dependencies.py
@@ -111,6 +111,14 @@ AppJson = namedtuple("AppJson", ["file_name", "content"])
 APP_JSON_INDENT = 4
 
 
+def _subprocess_env_without_pythonpath():
+    """Return a child-process environment without PYTHONPATH leakage."""
+
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    return env
+
+
 def _load_app_json(app_dir):
     json_files = [
         f
@@ -324,7 +332,8 @@ def main():
             local_wheel_dirs.extend(["-f", os.path.join(wheels_dir, sub_dir)])
 
         build_result = subprocess.run(
-            [pip_path, "wheel", "-w", temp_dir, "-r", requirements_file, *local_wheel_dirs]
+            [pip_path, "wheel", "-w", temp_dir, "-r", requirements_file, *local_wheel_dirs],
+            env=_subprocess_env_without_pythonpath(),
         )
 
         if build_result.returncode != 0:

--- a/local_hooks/package_app_dependencies.sh
+++ b/local_hooks/package_app_dependencies.sh
@@ -30,16 +30,21 @@ fi
 
 export PATH="$PY39_BIN:$PY313_BIN:$PATH"
 
+HOOKS_PYTHONPATH="${PYTHONPATH:-}"
+
 # Sanity check: We can import local_hooks, right? If not, it's probably because we were already
 # running in a docker container and we didn't volume mount the site-packages directory
 # If that's the case, try to import local_hooks from pre-commit Python's site-packages
 if ! python -c 'import local_hooks'; then
 	#shellcheck disable=SC2034,SC2046
-	PYTHONPATH="$($(dirname "$0")/python -c 'import site; print(site.getsitepackages()[0])')"
-	export PYTHONPATH
-	echo "$PYTHONPATH"
+	HOOKS_PYTHONPATH="$($(dirname "$0")/python -c 'import site; print(site.getsitepackages()[0])')"
+	export PYTHONPATH="$HOOKS_PYTHONPATH"
 	python -c 'import local_hooks'
 fi
+
+# The mounted pre-commit site-packages may contain host pip code from a newer Python version.
+# Limit that path to local_hooks imports so container pip3.9/pip3.13 use their own interpreter-local pip.
+unset PYTHONPATH
 
 # Remove any existing wheels in wheels/ and app json
 yum install jq -y
@@ -52,10 +57,19 @@ py39_deps='pip39_dependencies'
 py313_deps='pip313_dependencies'
 SCRIPT="python -m local_hooks.package_app_dependencies"
 
-pip3.9 install pip-tools
-${SCRIPT} . "$(which pip3.9)" "$py39_deps" --repair-wheels
+# Restore the hook import path only for the packager itself; child pip processes clear it again.
+run_packager() {
+	if [[ -n "${HOOKS_PYTHONPATH:-}" ]]; then
+		PYTHONPATH="$HOOKS_PYTHONPATH" ${SCRIPT} "$@"
+	else
+		${SCRIPT} "$@"
+	fi
+}
 
-pip3.13 install pip-tools
-${SCRIPT} . "$(which pip3.13)" "$py313_deps" --repair-wheels
+env -u PYTHONPATH pip3.9 install pip-tools
+run_packager . "$(which pip3.9)" "$py39_deps" --repair-wheels
+
+env -u PYTHONPATH pip3.13 install pip-tools
+run_packager . "$(which pip3.13)" "$py313_deps" --repair-wheels
 
 exit $?


### PR DESCRIPTION
Fix package-app-dependencies failing in CI due to host pre-commit PYTHONPATH leaking into container pip. The pre-commit env is now created on Python 3.13 with newer pip, and container pip3.9 was importing that
  host pip, causing a dataclass(..., slots=True) crash. This change isolates the pre-commit path for local_hooks imports only and clears it for container pip commands.
  
  Tested here by creating temporary PR with this branch as ref https://github.com/splunk-soar-connectors/salesforce/pull/24
  
Run verifying fix in repo with wheels in it - https://github.com/splunk-soar-connectors/googleworkspacefordrive/pull/35/changes (no more `TypeError: dataclass() got an unexpected keyword argument 'slots'` error

  Failure seen in multiple repos - 
  https://github.com/splunk-soar-connectors/salesforce/actions/runs/25104646229/job/73562620180?pr=22

  ```
  Traceback (most recent call last):
  File "/opt/python/cp39-cp39/bin/pip3.9", line 8, in <module>
    sys.exit(main())
  File "/site-packages/pip/_internal/cli/main.py", line 47, in main
    from pip._internal.cli.autocompletion import autocomplete
  File "/site-packages/pip/_internal/cli/autocompletion.py", line 12, in <module>
    from pip._internal.cli.main_parser import create_main_parser
  File "/site-packages/pip/_internal/cli/main_parser.py", line 11, in <module>
    from pip._internal.build_env import get_runnable_pip
  File "/site-packages/pip/_internal/build_env.py", line 22, in <module>
    from pip._internal.cli.spinners import open_rich_spinner, open_spinner
  File "/site-packages/pip/_internal/cli/spinners.py", line 22, in <module>
    from pip._internal.utils.logging import get_console, get_indentation
  File "/site-packages/pip/_internal/utils/logging.py", line 32, in <module>
    from pip._internal.utils.misc import StreamWrapper, ensure_dir
  File "/site-packages/pip/_internal/utils/misc.py", line 36, in <module>
    from pip._internal.locations import get_major_minor_version
  File "/site-packages/pip/_internal/locations/__init__.py", line 10, in <module>
    from pip._internal.models.scheme import SCHEME_KEYS, Scheme
  File "/site-packages/pip/_internal/models/scheme.py", line 13, in <module>
    @dataclass(frozen=True, slots=True)
TypeError: dataclass() got an unexpected keyword argument 'slots'
```