### PR TITLE
Add Analyst1 app id to registry mappings

### DIFF
--- a/local_hooks/data/appid_to_name.json
+++ b/local_hooks/data/appid_to_name.json
@@ -292,6 +292,7 @@
   "8e235e70-57eb-4292-9b7c-6cc44847d837": "Sumo Logic",
   "8e8be6eb-a509-45ca-8559-586cb592a6d8": "AWS Security Token Service",
   "8eca4888-4d1c-4310-bb0c-70136109cb4c": "AWS Athena",
+  "8ee822f1-a285-44f4-b8e7-303245811a32": "Analyst1",
   "8f9e2a5c-b1d4-4e7a-9c3f-6b8d5a2e4f71": "Cyberint IoC",
   "906542d8-1279-4629-a027-1f3c1e501ecc": "Fresh Service",
   "90a76493-0c71-4cb0-b5de-f66afe1c8cd7": "Cloaken",

--- a/local_hooks/data/appid_to_package_name.json
+++ b/local_hooks/data/appid_to_package_name.json
@@ -290,6 +290,7 @@
   "8e235e70-57eb-4292-9b7c-6cc44847d837": "phantom_sumologic",
   "8e8be6eb-a509-45ca-8559-586cb592a6d8": "phantom_awssts",
   "8eca4888-4d1c-4310-bb0c-70136109cb4c": "phantom_athena",
+  "8ee822f1-a285-44f4-b8e7-303245811a32": "phantom_analyst1",
   "8f9e2a5c-b1d4-4e7a-9c3f-6b8d5a2e4f71": "phantom_cyberintioc",
   "906542d8-1279-4629-a027-1f3c1e501ecc": "phantom_freshservice",
   "90a76493-0c71-4cb0-b5de-f66afe1c8cd7": "phantom_cloaken",


### PR DESCRIPTION
Registers the Analyst1 SOAR connector's app id in the CI tooling registry so its upstream repo (splunk-soar-connectors/analyst1) passes the app-name/package-name static checks.

- `appid_to_name.json`: `8ee822f1-a285-44f4-b8e7-303245811a32` -> `Analyst1`
- `appid_to_package_name.json`: `8ee822f1-a285-44f4-b8e7-303245811a32` -> `phantom_analyst1`

The app id is preserved from the existing Analyst1 app already published on
Splunkbase (v1.2.1). The SDK-based app contribution is open at
splunk-soar-connectors/analyst1#3; its app id static checks depend on this PR.
