### PR TITLE
fix(notice): run attribution lookup in one environment

### DIFF
--- a/local_hooks/generate_notice.py
+++ b/local_hooks/generate_notice.py
@@ -11,17 +11,24 @@ import glob
 import argparse
 import dataclasses
 import logging
+import shutil
+import sys
 from pathlib import Path
 from packaging.version import Version
+from packaging.utils import canonicalize_name
 import toml
 from local_hooks.helpers import find_uv_lock_file
 
 
 # pip-licenses is used to query all python packages for license information
 PYTHON_LICENSE_COMMAND = "pip-licenses"
-PYTHON_LICENSE_COMMAND_ARGS = (
-    "--format=json --with-license-file --no-license-path --with-urls --with-notice-file"
-)
+PYTHON_LICENSE_COMMAND_ARGS = [
+    "--format=json",
+    "--with-license-file",
+    "--no-license-path",
+    "--with-urls",
+    "--with-notice-file",
+]
 
 # A set of python packages that we've either already covered in the base
 # license files, or don't actually use.
@@ -124,17 +131,12 @@ class LicenseLine:
             f.write(line)
 
 
-def get_package_dependencies() -> list[str]:
+def get_package_dependencies(requirements_path: Path) -> list[str]:
     """
-    Enter the virtual environment for the current project.
-
-    This is necessary to ensure that the correct python packages are
-    being used.
+    Extract package names from the app requirements file.
     """
-    subprocess.run(["pip", "install", "pip-licenses"], capture_output=True).stdout
-    subprocess.run(["pip", "install", "-r", "requirements.txt"], capture_output=True).stdout
     packages = []
-    with open("requirements.txt") as reqs:
+    with open(requirements_path) as reqs:
         for line in reqs:
             if match := re.match(r"^(.*?)(?=[=<>])", line):
                 packages.append(match.group(0))
@@ -144,7 +146,91 @@ def get_package_dependencies() -> list[str]:
     return packages
 
 
-def get_python_license_info(packages: list[str]):
+def get_uv_tool_command() -> Optional[list[str]]:
+    if shutil.which("uvx"):
+        return ["uvx"]
+    if shutil.which("uv"):
+        return ["uv", "tool", "run"]
+    return None
+
+
+def run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    logging.debug("Running command: %s", shlex.join(command))
+    return subprocess.run(command, capture_output=True, text=True)
+
+
+def load_license_info(command: list[str]) -> list[dict]:
+    result = run_command(command)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Command failed with exit code {result.returncode}: {shlex.join(command)}"
+        )
+    return json.loads(result.stdout)
+
+
+def load_license_info_with_uvx(packages: list[str], requirements_path: Path) -> list[dict]:
+    uv_tool_command = get_uv_tool_command()
+    if uv_tool_command is None:
+        raise FileNotFoundError("uvx or uv is not available")
+
+    return load_license_info(
+        [
+            *uv_tool_command,
+            "--with-requirements",
+            str(requirements_path),
+            PYTHON_LICENSE_COMMAND,
+            *PYTHON_LICENSE_COMMAND_ARGS,
+            "--packages",
+            *packages,
+        ]
+    )
+
+
+def load_license_info_with_pip(packages: list[str], requirements_path: Path) -> list[dict]:
+    pip_check = run_command([sys.executable, "-m", "pip", "--version"])
+    if pip_check.returncode != 0:
+        raise RuntimeError(
+            f"uvx/uv is not available and pip is not importable from {sys.executable}"
+        )
+
+    install_command = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "pip-licenses",
+        "-r",
+        str(requirements_path),
+    ]
+    install_result = run_command(install_command)
+    if install_result.returncode != 0:
+        raise RuntimeError(
+            f"Command failed with exit code {install_result.returncode}: "
+            f"{shlex.join(install_command)}"
+        )
+
+    return load_license_info(
+        [
+            sys.executable,
+            "-m",
+            "piplicenses",
+            *PYTHON_LICENSE_COMMAND_ARGS,
+            "--packages",
+            *packages,
+        ]
+    )
+
+
+def get_license_info_list(packages: list[str], requirements_path: Path) -> list[dict]:
+    try:
+        return load_license_info_with_uvx(packages, requirements_path)
+    except (FileNotFoundError, RuntimeError) as uv_error:
+        logging.warning("uvx pip-licenses failed; falling back to pip: %s", uv_error)
+
+    return load_license_info_with_pip(packages, requirements_path)
+
+
+def get_python_license_info(packages: list[str], requirements_path: Path):
     """
     Generate a series of LicenseLine objects describing every python dependency
     in the current environment.
@@ -152,13 +238,15 @@ def get_python_license_info(packages: list[str]):
     This uses the tool pip-licenses to automatically collect all package
     information by grabbing all packages in the current environment.
     """
-    command = shlex.split(
-        f"{PYTHON_LICENSE_COMMAND} {PYTHON_LICENSE_COMMAND_ARGS} --packages {' '.join(packages)}"
-    )
-    license_info_proc = subprocess.run(command, capture_output=True).stdout
-
     # A very large json array is returned. Missing values are marked 'UNKNOWN'
-    license_info_list = json.loads(license_info_proc)
+    license_info_list = get_license_info_list(packages, requirements_path)
+    found_packages = {canonicalize_name(info.get("Name", "")) for info in license_info_list}
+    missing_packages = {canonicalize_name(package) for package in packages} - found_packages
+    if missing_packages:
+        raise RuntimeError(
+            "pip-licenses did not return license information for: "
+            f"{', '.join(sorted(missing_packages))}"
+        )
 
     for license_info in license_info_list:
         if license_info.get("Name") not in EXCLUDED_PYTHON_PACKAGES:
@@ -281,7 +369,8 @@ def main():
         f.write(f"Splunk SOAR App: {app_name}\n{app_license}\n")
 
         # Get all python package dependencies
-        packages = get_package_dependencies()
+        requirements_path = connector_path / "requirements.txt"
+        packages = get_package_dependencies(requirements_path)
         valid_packages = [
             package for package in packages if package not in EXCLUDED_PYTHON_PACKAGES
         ]
@@ -291,7 +380,9 @@ def main():
             return
 
         # Get license info for all package dependencies
-        for item in get_python_license_info(packages=valid_packages):
+        for item in get_python_license_info(
+            packages=valid_packages, requirements_path=requirements_path
+        ):
             item.write_line(f)
 
     remove_trailing_whitespace(notice_file_path)

--- a/local_hooks/tests/test_generate_notice.py
+++ b/local_hooks/tests/test_generate_notice.py
@@ -1,0 +1,170 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from local_hooks import generate_notice
+
+
+def license_rows(*names: str) -> str:
+    return json.dumps(
+        [
+            {
+                "Name": name,
+                "License": "MIT",
+                "LicenseText": "Permission granted.",
+                "NoticeText": "UNKNOWN",
+                "URL": f"https://example.test/{name}",
+                "Version": "1.0.0",
+            }
+            for name in names
+        ]
+    )
+
+
+def completed(command: list[str], stdout: str = "", returncode: int = 0):
+    return subprocess.CompletedProcess(command, returncode, stdout=stdout, stderr="")
+
+
+def test_get_python_license_info_prefers_uvx(monkeypatch, tmp_path: Path):
+    requirements_path = tmp_path / "requirements.txt"
+    requirements_path.write_text("demo-package==1.0.0\n")
+    commands = []
+
+    monkeypatch.setattr(
+        generate_notice.shutil,
+        "which",
+        lambda command: "/usr/bin/uvx" if command == "uvx" else None,
+    )
+
+    def fake_run(command: list[str]):
+        commands.append(command)
+        return completed(command, license_rows("demo-package"))
+
+    monkeypatch.setattr(generate_notice, "run_command", fake_run)
+
+    rows = list(generate_notice.get_python_license_info(["demo-package"], requirements_path))
+
+    assert [row.package_name for row in rows] == ["demo-package"]
+    assert commands == [
+        [
+            "uvx",
+            "--with-requirements",
+            str(requirements_path),
+            "pip-licenses",
+            "--format=json",
+            "--with-license-file",
+            "--no-license-path",
+            "--with-urls",
+            "--with-notice-file",
+            "--packages",
+            "demo-package",
+        ]
+    ]
+
+
+def test_get_python_license_info_can_use_uv_tool_run(monkeypatch, tmp_path: Path):
+    requirements_path = tmp_path / "requirements.txt"
+    requirements_path.write_text("demo-package==1.0.0\n")
+    commands = []
+
+    monkeypatch.setattr(
+        generate_notice.shutil,
+        "which",
+        lambda command: "/usr/bin/uv" if command == "uv" else None,
+    )
+
+    def fake_run(command: list[str]):
+        commands.append(command)
+        return completed(command, license_rows("demo-package"))
+
+    monkeypatch.setattr(generate_notice, "run_command", fake_run)
+
+    rows = list(generate_notice.get_python_license_info(["demo-package"], requirements_path))
+
+    assert [row.package_name for row in rows] == ["demo-package"]
+    assert commands[0][:4] == ["uv", "tool", "run", "--with-requirements"]
+
+
+def test_get_python_license_info_falls_back_to_current_python_pip(monkeypatch, tmp_path: Path):
+    requirements_path = tmp_path / "requirements.txt"
+    requirements_path.write_text("demo-package==1.0.0\n")
+    commands = []
+
+    monkeypatch.setattr(generate_notice.shutil, "which", lambda command: None)
+
+    def fake_run(command: list[str]):
+        commands.append(command)
+        if command == [sys.executable, "-m", "pip", "--version"]:
+            return completed(command, "pip 1.0\n")
+        if command[:4] == [sys.executable, "-m", "pip", "install"]:
+            return completed(command)
+        if command[:3] == [sys.executable, "-m", "piplicenses"]:
+            return completed(command, license_rows("demo-package"))
+        raise AssertionError(f"Unexpected command: {command}")
+
+    monkeypatch.setattr(generate_notice, "run_command", fake_run)
+
+    rows = list(generate_notice.get_python_license_info(["demo-package"], requirements_path))
+
+    assert [row.package_name for row in rows] == ["demo-package"]
+    assert commands == [
+        [sys.executable, "-m", "pip", "--version"],
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "pip-licenses",
+            "-r",
+            str(requirements_path),
+        ],
+        [
+            sys.executable,
+            "-m",
+            "piplicenses",
+            "--format=json",
+            "--with-license-file",
+            "--no-license-path",
+            "--with-urls",
+            "--with-notice-file",
+            "--packages",
+            "demo-package",
+        ],
+    ]
+
+
+def test_get_python_license_info_fails_without_uv_or_pip(monkeypatch, tmp_path: Path):
+    requirements_path = tmp_path / "requirements.txt"
+    requirements_path.write_text("demo-package==1.0.0\n")
+
+    monkeypatch.setattr(generate_notice.shutil, "which", lambda command: None)
+    monkeypatch.setattr(
+        generate_notice,
+        "run_command",
+        lambda command: completed(command, returncode=1),
+    )
+
+    with pytest.raises(RuntimeError, match="pip is not importable"):
+        list(generate_notice.get_python_license_info(["demo-package"], requirements_path))
+
+
+def test_get_python_license_info_fails_when_license_rows_are_missing(monkeypatch, tmp_path: Path):
+    requirements_path = tmp_path / "requirements.txt"
+    requirements_path.write_text("demo-package==1.0.0\n")
+
+    monkeypatch.setattr(
+        generate_notice.shutil,
+        "which",
+        lambda command: "/usr/bin/uvx" if command == "uvx" else None,
+    )
+    monkeypatch.setattr(
+        generate_notice,
+        "run_command",
+        lambda command: completed(command, "[]"),
+    )
+
+    with pytest.raises(RuntimeError, match="demo-package"):
+        list(generate_notice.get_python_license_info(["demo-package"], requirements_path))


### PR DESCRIPTION
Written by Codex.

## Summary

This fixes NOTICE attribution generation so dependency installation and `pip-licenses` lookup run in the same environment.

The default path now uses `uvx --with-requirements <requirements.txt> pip-licenses ...`, with a fallback to the current Python interpreter's `pip` and `piplicenses` module when uv is unavailable. The hook now fails when expected non-excluded package rows are missing, which prevents header-only NOTICE output.

## Root Cause

The previous hook called bare `pip install ...` and then ran `pip-licenses` from the hook environment. On machines where `pip` resolves outside the pre-commit hook environment, requirements could be installed into a different Python environment while `pip-licenses` returned no rows.

## Validation

- `pre-commit run --files local_hooks/generate_notice.py local_hooks/tests/test_generate_notice.py`
- `uv run --with pytest pytest local_hooks/tests/test_generate_notice.py`
- Temp ThreatStream NOTICE generation produced attribution blocks for `dnspython`, `ipwhois`, and `wizard-whois`.
- From `local_hooks/`: `uv run --project .. --with pytest pytest tests/test_generate_notice.py tests/test_build_docs.py tests/test_release_notes.py tests/test_copyright_updates.py tests/test_static_tests.py`
