### PR TITLE
PAPP-37955: fix: allow empty packaged dependency sets

### DIFF
--- a/local_hooks/app_tests/json_tests.py
+++ b/local_hooks/app_tests/json_tests.py
@@ -528,7 +528,7 @@ class JSONTests(TestSuite):
     @TestSuite.test
     def check_pip313_dependencies(self):
         """
-        Ensures pip313_dependencies key exists and has appropriate content based on requirements.txt
+        Ensures pip313_dependencies exists and has the generated dictionary structure
         """
         if self._parser.uv_lock_filepath:
             return SKIP_SDK_APP
@@ -536,9 +536,9 @@ class JSONTests(TestSuite):
         verbose = []
         message = TEST_PASS_MESSAGE
 
-        # Check if requirements.txt exists and read its content
+        # The packager can legitimately produce no bundled wheels when every requirement is
+        # provided by SOAR. In that case it still writes an empty dependency dictionary.
         requirements_file = self._app_code_dir / "requirements.txt"
-        has_requirements = False
         requirements_file_exists = requirements_file.exists()
 
         # If no requirements.txt file exists, we don't care about pip313_dependencies
@@ -547,20 +547,6 @@ class JSONTests(TestSuite):
                 success=True,
                 message=TEST_PASS_MESSAGE,
                 verbose=["No requirements.txt found - pip313_dependencies check skipped"],
-            )
-
-        # Read requirements.txt content
-        try:
-            requirements_content = requirements_file.read_text().strip()
-            # Check if requirements.txt has any non-empty, non-comment lines
-            has_requirements = any(
-                line.strip() and not line.strip().startswith("#")
-                for line in requirements_content.splitlines()
-            )
-        except Exception as e:
-            verbose.append(f"Error reading requirements.txt: {e}")
-            return create_test_result_response(
-                success=False, message="Could not read requirements.txt file", verbose=verbose
             )
 
         # Check if pip313_dependencies key exists in app json
@@ -573,21 +559,8 @@ class JSONTests(TestSuite):
             )
 
         pip313_deps = self._app_json["pip313_dependencies"]
-
-        # If requirements.txt is empty or has no real requirements
-        if not has_requirements:
-            # pip313_dependencies can be empty (but should still be a dict)
-            if not isinstance(pip313_deps, dict):
-                verbose.append("pip313_dependencies should be a dictionary")
-                message = "pip313_dependencies must be a dictionary structure"
-        else:
-            # If requirements.txt has content, pip313_dependencies should not be empty
-            if not pip313_deps or (isinstance(pip313_deps, dict) and not any(pip313_deps.values())):
-                verbose.append(
-                    "pip313_dependencies should not be empty when requirements.txt contains packages"
-                )
-                message = (
-                    "pip313_dependencies must have values when requirements.txt contains packages"
-                )
+        if not isinstance(pip313_deps, dict):
+            verbose.append("pip313_dependencies should be a dictionary")
+            message = "pip313_dependencies must be a dictionary structure"
 
         return create_test_result_response(success=not verbose, message=message, verbose=verbose)

--- a/local_hooks/app_tests/utils/app_parser.py
+++ b/local_hooks/app_tests/utils/app_parser.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Optional
 from local_hooks.helpers import (
     find_uv_lock_file,
-    load_sdk_apps_enviornment,
+    load_sdk_apps_environment,
     generate_sdk_app_manifest,
 )
 
@@ -113,7 +113,7 @@ class AppParser:
     @cached_property
     def sdk_app_json(self) -> Path:
         uv_lock_dir = self.uv_lock_filepath.parent
-        load_sdk_apps_enviornment(uv_lock_dir)
+        load_sdk_apps_environment(uv_lock_dir)
         return generate_sdk_app_manifest(uv_lock_dir)
 
     @cached_property

--- a/local_hooks/build_docs.py
+++ b/local_hooks/build_docs.py
@@ -23,7 +23,7 @@ from jinja2.ext import Extension
 from jinja2.lexer import Token, TokenStream
 from local_hooks.helpers import (
     find_uv_lock_file,
-    load_sdk_apps_enviornment,
+    load_sdk_apps_environment,
     generate_sdk_app_manifest,
 )
 
@@ -100,7 +100,7 @@ def get_app_json(app_json_dir, json_name):
         logging.info("SDK app detected, generating manifest: UV_LOCK_DIR=%s", uv_lock_dir)
 
         # Install dependencies from pyproject.toml using uv
-        load_sdk_apps_enviornment(uv_lock_dir)
+        load_sdk_apps_environment(uv_lock_dir)
 
         # Generate the SDK manifest in a temporary directory
         logging.info("Generating SDK app manifest in temporary directory")

--- a/local_hooks/helpers.py
+++ b/local_hooks/helpers.py
@@ -58,7 +58,7 @@ def find_uv_lock_file(connector_path: Path) -> Optional[Path]:
         return uv_lock_path
 
 
-def load_sdk_apps_enviornment(uv_lock_dir: Path):
+def load_sdk_apps_environment(uv_lock_dir: Path):
     """
     Load the SDK app's environment.
     """

--- a/local_hooks/tests/test_static_tests.py
+++ b/local_hooks/tests/test_static_tests.py
@@ -70,7 +70,7 @@ def test_static_tests(app_dir: Path):
     ["tests/data/static_tests/sdk_app_dir"],
     indirect=["sdk_app_dir"],
 )
-@patch("local_hooks.app_tests.utils.app_parser.load_sdk_apps_enviornment")
+@patch("local_hooks.app_tests.utils.app_parser.load_sdk_apps_environment")
 @patch("local_hooks.app_tests.utils.app_parser.generate_sdk_app_manifest")
 def test_static_tests_sdkfied_app(mock_generate_manifest, mock_load_env, sdk_app_dir: Path):
     sdk_manifest_path = Path("tests/data/static_tests/sdk_app_dir/sdk_app_manifest.json")

--- a/local_hooks/tests/test_static_tests.py
+++ b/local_hooks/tests/test_static_tests.py
@@ -3,10 +3,13 @@ import os
 import shutil
 import subprocess
 import json
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 from pathlib import Path
+
+from local_hooks.app_tests.json_tests import JSONTests
 
 PRE_COMMIT_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
@@ -96,3 +99,31 @@ def test_static_tests_sdkfied_app(mock_generate_manifest, mock_load_env, sdk_app
         os.chdir(original_cwd)
 
     assert exit_code == 4
+
+
+def test_pip313_dependencies_allows_empty_generated_wheel_set(tmp_path: Path):
+    """SOAR-provided requirements do not need redundant bundled wheels."""
+    (tmp_path / "requirements.txt").write_text("beautifulsoup4==4.12.2\n")
+    suite = JSONTests.__new__(JSONTests)
+    suite._app_code_dir = tmp_path
+    suite._parser = SimpleNamespace(uv_lock_filepath=None)
+    suite._app_json = {"pip313_dependencies": {"wheel": []}}
+
+    result = suite.check_pip313_dependencies()
+
+    assert result["success"] is True
+
+
+def test_pip313_dependencies_still_requires_generated_key(tmp_path: Path):
+    (tmp_path / "requirements.txt").write_text("beautifulsoup4==4.12.2\n")
+    suite = JSONTests.__new__(JSONTests)
+    suite._app_code_dir = tmp_path
+    suite._parser = SimpleNamespace(uv_lock_filepath=None)
+    suite._app_json = {}
+
+    result = suite.check_pip313_dependencies()
+
+    assert result["success"] is False
+    assert result["message"] == (
+        "App json must contain 'pip313_dependencies' key when requirements.txt exists"
+    )

--- a/local_hooks/tests/test_static_tests.py
+++ b/local_hooks/tests/test_static_tests.py
@@ -70,8 +70,8 @@ def test_static_tests(app_dir: Path):
     ["tests/data/static_tests/sdk_app_dir"],
     indirect=["sdk_app_dir"],
 )
-@patch("local_hooks.helpers.load_sdk_apps_enviornment")
-@patch("local_hooks.helpers.generate_sdk_app_manifest")
+@patch("local_hooks.app_tests.utils.app_parser.load_sdk_apps_enviornment")
+@patch("local_hooks.app_tests.utils.app_parser.generate_sdk_app_manifest")
 def test_static_tests_sdkfied_app(mock_generate_manifest, mock_load_env, sdk_app_dir: Path):
     sdk_manifest_path = Path("tests/data/static_tests/sdk_app_dir/sdk_app_manifest.json")
     with open(sdk_manifest_path) as f:


### PR DESCRIPTION
## Summary

Allow the static dependency validator to accept an empty generated `pip313_dependencies`
dictionary while continuing to require the key and dictionary shape.

## Why

The dependency packager deliberately excludes packages supplied by SOAR. Apps such as Mimecast
and Automox can therefore have a nonempty `requirements.txt` but no wheels that need bundling. The
packager correctly writes `{"wheel": []}`, but the following static-test hook rejects that valid
output, leaving both connector PRs blocked.

## Changes

- Remove the incorrect assumption that every requirements file must produce at least one bundled
  Python 3.13 wheel.
- Preserve validation that `pip313_dependencies` exists when `requirements.txt` exists.
- Preserve validation that the generated value is a dictionary.
- Add regression tests for a valid empty generated wheel set and a missing generated key.

## Validation

- `pre-commit run --all-files`
- Regression tests under Python 3.9 (CI version): 2 passed
- Regression tests under Python 3.13: 2 passed
- Ruff lint and formatting checks
- Python compilation

## Tracking

- [PAPP-37955](https://splunk.atlassian.net/browse/PAPP-37955)
- Blocks [Mimecast connector PR #26](https://github.com/splunk-soar-connectors/mimecast/pull/26)
- Also blocks [Automox connector PR #6](https://github.com/splunk-soar-connectors/automox/pull/6)

Written by Codex.
