### PR TITLE
fix: allow empty unreleased notes

### DIFF
--- a/local_hooks/release_notes.py
+++ b/local_hooks/release_notes.py
@@ -33,7 +33,7 @@ def check_release_notes(app_directory: str):
         release_notes.insert(0, UNRELEASED_MD_HEADER)
 
     if len(release_notes) == 1:
-        raise ValueError("Release notes file is empty. Please populate it with release notes.")
+        return
 
     parent_depths = []
     for i in range(1, len(release_notes)):

--- a/local_hooks/tests/data/release_notes/release_notes_empty/release_notes/unreleased.md
+++ b/local_hooks/tests/data/release_notes/release_notes_empty/release_notes/unreleased.md
@@ -1,0 +1,1 @@
+**Unreleased**

--- a/local_hooks/tests/test_release_notes.py
+++ b/local_hooks/tests/test_release_notes.py
@@ -43,6 +43,20 @@ def test_release_notes_passing(app_dir: Path):
 
 @pytest.mark.parametrize(
     "app_dir",
+    ["tests/data/release_notes/release_notes_empty"],
+    indirect=["app_dir"],
+)
+def test_header_only_release_notes_passes(app_dir: Path):
+    result = subprocess.run(
+        ["release-notes", "."],
+        cwd=app_dir,
+        capture_output=True,
+    )
+    assert result.returncode == 0
+
+
+@pytest.mark.parametrize(
+    "app_dir",
     ["tests/data/release_notes/release_notes_failing/actual"],
     indirect=["app_dir"],
 )


### PR DESCRIPTION
## Summary

- allow an existing header-only `release_notes/unreleased.md` file
- retain missing-file handling and populated release-note format correction
- add regression coverage for tooling-only connector commits

## Why

The shared hook unconditionally rejected required pre-commit baseline commits when the unreleased file was intentionally empty. Connector policy forbids inventing a user-visible release note for tooling-only changes, so the hook blocked every fresh campaign repo before functional work could begin.

Tracking: PAPP-37959 under ESPM-5228.

## Validation

- `UV_PROJECT_ENVIRONMENT=/tmp/codex-dev-cicd-tools-py313 uv run --python /opt/homebrew/bin/python3.13 --with pytest pytest -q tests/test_release_notes.py` (3 passed)
- `pre-commit run --all-files`
- `git diff --check`

Written by Codex.