### PR TITLE
fix: parse VCS requirements for NOTICE generation

### DIFF
--- a/local_hooks/generate_notice.py
+++ b/local_hooks/generate_notice.py
@@ -15,6 +15,7 @@ import shutil
 import sys
 from pathlib import Path
 from packaging.version import Version
+from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import canonicalize_name
 import toml
 from local_hooks.helpers import find_uv_lock_file
@@ -131,6 +132,31 @@ class LicenseLine:
             f.write(line)
 
 
+LEGACY_VCS_NAME = re.compile(r"\s+#(?P<name>[A-Za-z0-9_.-]+)=[^\s]+\s*$")
+VCS_EGG_NAME = re.compile(r"[#&]egg=(?P<name>[A-Za-z0-9_.-]+)(?:&|$)")
+
+
+def get_requirement_name(line: str) -> Optional[str]:
+    """Return the distribution name represented by one requirements line."""
+    requirement_text = line.strip()
+    if not requirement_text or requirement_text.startswith("#"):
+        return None
+
+    if legacy_match := LEGACY_VCS_NAME.search(line):
+        return canonicalize_name(legacy_match.group("name"))
+    if egg_match := VCS_EGG_NAME.search(requirement_text):
+        return canonicalize_name(egg_match.group("name"))
+
+    # Whitespace starts an inline comment in requirements files. Preserve URL
+    # fragments by only splitting on whitespace followed by '#'.
+    requirement_text = re.split(r"\s+#", requirement_text, maxsplit=1)[0].strip()
+    try:
+        return canonicalize_name(Requirement(requirement_text).name)
+    except InvalidRequirement:
+        logging.error("Unable to extract package from requirement: %s", line.rstrip())
+        return None
+
+
 def get_package_dependencies(requirements_path: Path) -> list[str]:
     """
     Extract package names from the app requirements file.
@@ -138,11 +164,9 @@ def get_package_dependencies(requirements_path: Path) -> list[str]:
     packages = []
     with open(requirements_path) as reqs:
         for line in reqs:
-            if match := re.match(r"^(.*?)(?=[=<>])", line):
-                packages.append(match.group(0))
-                logging.info(f"Found package: {match.group(0)}")
-            else:
-                print(f"ERROR extracting package from line: {line}")
+            if package := get_requirement_name(line):
+                packages.append(package)
+                logging.info("Found package: %s", package)
     return packages
 
 

--- a/local_hooks/tests/test_generate_notice.py
+++ b/local_hooks/tests/test_generate_notice.py
@@ -28,6 +28,33 @@ def completed(command: list[str], stdout: str = "", returncode: int = 0):
     return subprocess.CompletedProcess(command, returncode, stdout=stdout, stderr="")
 
 
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        (
+            "git+https://github.com/phantomcyber/convert-outlook-msg-file.git@0.1.0 "
+            "#outlookmsgfile=0.1.0",
+            "outlookmsgfile",
+        ),
+        (
+            "outlookmsgfile @ "
+            "git+https://github.com/phantomcyber/convert-outlook-msg-file.git@0.1.0",
+            "outlookmsgfile",
+        ),
+        (
+            "git+https://github.com/example/project.git@1.0#egg=Example_Project",
+            "example-project",
+        ),
+        ("lxml==5.4.0", "lxml"),
+        ("Requests>=2.32 # runtime HTTP client", "requests"),
+        ("", None),
+        ("# comment", None),
+    ],
+)
+def test_get_requirement_name(line: str, expected):
+    assert generate_notice.get_requirement_name(line) == expected
+
+
 def test_get_python_license_info_prefers_uvx(monkeypatch, tmp_path: Path):
     requirements_path = tmp_path / "requirements.txt"
     requirements_path.write_text("demo-package==1.0.0\n")


### PR DESCRIPTION
Fix NOTICE generation for connector requirements that use VCS URLs.\n\nThe current regex treats the first comparator anywhere in the line as the package-name boundary. For the Office365 legacy VCS requirement pointing at phantomcyber/convert-outlook-msg-file with the fragment #outlookmsgfile=0.1.0, that sends a malformed URL-derived value to pip-licenses and blocks the connector before any remediation commit.\n\nThis change:\n- parses standard and PEP 508 direct requirements with packaging.Requirement\n- supports legacy #egg=name VCS fragments\n- supports the connector convention #name=version\n- canonicalizes only the extracted distribution name\n- ignores blank and comment-only lines\n\nTracking: PAPP-37972 under ESPM-5228.\n\nValidation:\n- focused generate_notice tests: 12 passed\n- ruff check and format pass\n- Python compilation and diff checks pass\n- broader local-hooks suite: 21 passed; six unrelated Docker packaging tests fail because the local container cannot import local_hooks or find /srv/python\n\nWritten by Codex on behalf of Jacob D.