### PR TITLE
feat(ci): automate semantic releases

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,0 +1,33 @@
+name: Semantic Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  semantic-release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: semantic-release-${{ github.ref }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+
+      - name: Install semantic-release dependencies
+        run: npm install --global semantic-release conventional-changelog-conventionalcommits
+
+      - name: Run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,19 @@
+{
+  "branches": ["main"],
+  "tagFormat": "v${version}",
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
## Summary

- Run semantic-release automatically after changes land on `main`.
- Derive release versions and generated notes from Conventional Commits.
- Create GitHub releases and tags using the repository's existing `vX.Y.Z` convention.

## Why

Releases and tags are currently created manually, which makes the process inconsistent and easy to miss. This change makes release creation deterministic while preserving the established tag format.

## Impact

The merge commit for this PR is a `feat(ci)`, so the first automated run is expected to create release and tag `v2.2.0` from the current `v2.1.7` baseline. Future `fix`, `feat`, and breaking commits will drive patch, minor, and major releases respectively; commits that do not require a release will not create one.

## Validation

- Repository pre-commit hooks passed.
- Actionlint passed.
- JSON parsing and `git diff --check` passed.
- A semantic-release dry run authenticated successfully, found `v2.1.7`, analyzed the commit as a minor release, and calculated `v2.2.0` without creating a tag or release.

---

PR authored by Codex.
