### PR TITLE
fix: allow notice generation without requirements

### DIFF
--- a/local_hooks/generate_notice.py
+++ b/local_hooks/generate_notice.py
@@ -161,6 +161,10 @@ def get_package_dependencies(requirements_path: Path) -> list[str]:
     """
     Extract package names from the app requirements file.
     """
+    if not requirements_path.is_file():
+        logging.info("No requirements file found at %s", requirements_path)
+        return []
+
     packages = []
     with open(requirements_path) as reqs:
         for line in reqs:

--- a/local_hooks/tests/test_generate_notice.py
+++ b/local_hooks/tests/test_generate_notice.py
@@ -55,6 +55,10 @@ def test_get_requirement_name(line: str, expected):
     assert generate_notice.get_requirement_name(line) == expected
 
 
+def test_get_package_dependencies_allows_missing_requirements(tmp_path: Path):
+    assert generate_notice.get_package_dependencies(tmp_path / "requirements.txt") == []
+
+
 def test_get_python_license_info_prefers_uvx(monkeypatch, tmp_path: Path):
     requirements_path = tmp_path / "requirements.txt"
     requirements_path.write_text("demo-package==1.0.0\n")


### PR DESCRIPTION
## Summary

- Treat a missing connector `requirements.txt` as an empty dependency set during NOTICE generation.
- Add a regression test for legacy dependency-free connectors.

This removes a central pre-commit blocker discovered while onboarding the AirWatch connector. Adding an empty connector-local requirements file would only mask the shared hook defect.

Tracking: [PAPP-38004](https://splunk.atlassian.net/browse/PAPP-38004), [PSAAS-31339](https://splunk.atlassian.net/browse/PSAAS-31339), [PSAAS-31406](https://splunk.atlassian.net/browse/PSAAS-31406).

## Testing

- `pre-commit run --all-files`
- `python3 -m py_compile local_hooks/generate_notice.py`
- `uv run --project . --with pytest pytest local_hooks/tests/test_generate_notice.py` — 13 passed
- Full local hook suite: 22 passed; six existing amd64 Docker packaging cases cannot execute on this arm64 host and fail before reaching the changed NOTICE code. Hosted CI is the authoritative packaging gate.

Written by Codex with AI assistance.
