### PR TITLE
fix: make NOTICE generation idempotent

### DIFF
--- a/local_hooks/generate_notice.py
+++ b/local_hooks/generate_notice.py
@@ -337,11 +337,12 @@ def remove_trailing_blank_lines(notice_file_path: Path):
     while lines and lines[-1].strip() == "":
         lines.pop()
 
-    # Rewrite the file with cleaned content
+    # Rewrite the file with cleaned content and exactly one terminal newline.
+    # The preceding whitespace pass can leave the final content line already
+    # newline-terminated, so writelines() followed by write("\n") would create
+    # a blank line and make the hook non-idempotent.
     with open(notice_file_path, "w") as f:
-        f.writelines(lines)
-        # Ensure there's a single newline at the end of the file
-        f.write("\n")
+        f.write("".join(lines).rstrip("\n") + "\n")
 
 
 def get_sdk_version_from_lock(uv_lock_path: Path) -> Optional[Version]:

--- a/local_hooks/tests/test_generate_notice.py
+++ b/local_hooks/tests/test_generate_notice.py
@@ -199,3 +199,13 @@ def test_get_python_license_info_fails_when_license_rows_are_missing(monkeypatch
 
     with pytest.raises(RuntimeError, match="demo-package"):
         list(generate_notice.get_python_license_info(["demo-package"], requirements_path))
+
+
+def test_notice_cleanup_is_idempotent(tmp_path: Path):
+    notice_path = tmp_path / "NOTICE"
+    notice_path.write_text("first line  \nlast line\n\n")
+
+    for _ in range(2):
+        generate_notice.remove_trailing_whitespace(notice_path)
+        generate_notice.remove_trailing_blank_lines(notice_path)
+        assert notice_path.read_bytes() == b"first line\nlast line\n"


### PR DESCRIPTION
Written and opened by Codex.

PAPP: [PAPP-38045](https://splunk.atlassian.net/browse/PAPP-38045)
Observed failure: [Shodan pre-commit job](https://github.com/splunk-soar-connectors/shodanapi/actions/runs/29553941149/job/87802132626)

## Root cause

NOTICE generation runs two cleanup passes. The whitespace pass leaves the final content line newline-terminated; the blank-line pass then wrote those lines and unconditionally appended another newline. That produces a trailing blank line on every clean CI checkout and makes the hook fail after modifying an otherwise canonical NOTICE file.

## Changes

- Normalize the rewritten NOTICE to exactly one terminal newline.
- Add a two-pass regression test that proves cleanup is idempotent and removes trailing spaces and blank lines.

## Validation

- `PYTHONPATH=. uv run --no-project --python 3.13 --with pytest --with packaging --with toml python -m pytest -q local_hooks/tests/test_generate_notice.py` — 14 passed.
- Changed-file pre-commit hooks passed.
- `git diff --check` passed.
