### PR TITLE
fix: write generated notices atomically

### DIFF
--- a/local_hooks/generate_notice.py
+++ b/local_hooks/generate_notice.py
@@ -10,9 +10,11 @@ from typing import Optional
 import glob
 import argparse
 import dataclasses
+import io
 import logging
 import shutil
 import sys
+import tempfile
 from pathlib import Path
 from packaging.version import Version
 from packaging.requirements import InvalidRequirement, Requirement
@@ -416,29 +418,34 @@ def main():
     notice_file_path = connector_path / "NOTICE"
     logging.info("Creating NOTICE file at %s", Path(notice_file_path.resolve()))
 
-    with open(notice_file_path, "w") as f:
-        # Write base license file
-        f.write(f"Splunk SOAR App: {app_name}\n{app_license}\n")
+    requirements_path = connector_path / "requirements.txt"
+    packages = get_package_dependencies(requirements_path)
+    valid_packages = [package for package in packages if package not in EXCLUDED_PYTHON_PACKAGES]
+    license_lines = (
+        list(get_python_license_info(packages=valid_packages, requirements_path=requirements_path))
+        if valid_packages
+        else []
+    )
 
-        # Get all python package dependencies
-        requirements_path = connector_path / "requirements.txt"
-        packages = get_package_dependencies(requirements_path)
-        valid_packages = [
-            package for package in packages if package not in EXCLUDED_PYTHON_PACKAGES
-        ]
-        if valid_packages:
-            f.write("Third Party Software Attributions:\n")
-        else:
-            return
+    rendered = io.StringIO()
+    rendered.write(f"Splunk SOAR App: {app_name}\n{app_license}\n")
+    if license_lines:
+        rendered.write("Third Party Software Attributions:\n")
+        for item in license_lines:
+            item.write_line(rendered)
+    content = "\n".join(line.rstrip() for line in rendered.getvalue().splitlines()).rstrip() + "\n"
 
-        # Get license info for all package dependencies
-        for item in get_python_license_info(
-            packages=valid_packages, requirements_path=requirements_path
-        ):
-            item.write_line(f)
-
-    remove_trailing_whitespace(notice_file_path)
-    remove_trailing_blank_lines(notice_file_path)
+    temporary_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w", dir=connector_path, prefix=".NOTICE.", delete=False
+        ) as temporary:
+            temporary.write(content)
+            temporary_path = Path(temporary.name)
+        temporary_path.replace(notice_file_path)
+    finally:
+        if temporary_path and temporary_path.exists():
+            temporary_path.unlink()
 
 
 def parse_args() -> BuildDocsArgs:

--- a/local_hooks/generate_notice.py
+++ b/local_hooks/generate_notice.py
@@ -426,6 +426,8 @@ def main():
         if valid_packages
         else []
     )
+    if valid_packages and not license_lines:
+        raise RuntimeError("Unable to collect license metadata for connector dependencies")
 
     rendered = io.StringIO()
     rendered.write(f"Splunk SOAR App: {app_name}\n{app_license}\n")

--- a/local_hooks/tests/test_generate_notice.py
+++ b/local_hooks/tests/test_generate_notice.py
@@ -209,3 +209,29 @@ def test_notice_cleanup_is_idempotent(tmp_path: Path):
         generate_notice.remove_trailing_whitespace(notice_path)
         generate_notice.remove_trailing_blank_lines(notice_path)
         assert notice_path.read_bytes() == b"first line\nlast line\n"
+
+
+def test_notice_is_unchanged_when_license_collection_fails(monkeypatch, tmp_path: Path):
+    manifest = {
+        "name": "Example",
+        "license": "Copyright (c) 2026 Splunk Inc.",
+    }
+    (tmp_path / "example.json").write_text(json.dumps(manifest))
+    (tmp_path / "requirements.txt").write_text("demo-package==1.0.0\n")
+    notice_path = tmp_path / "NOTICE"
+    notice_path.write_text("existing notice\n")
+    monkeypatch.setattr(
+        generate_notice,
+        "get_python_license_info",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("license failure")),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["generate_notice.py", str(tmp_path)],
+    )
+
+    with pytest.raises(RuntimeError, match="license failure"):
+        generate_notice.main()
+
+    assert notice_path.read_text() == "existing notice\n"

--- a/local_hooks/tests/test_generate_notice.py
+++ b/local_hooks/tests/test_generate_notice.py
@@ -235,3 +235,21 @@ def test_notice_is_unchanged_when_license_collection_fails(monkeypatch, tmp_path
         generate_notice.main()
 
     assert notice_path.read_text() == "existing notice\n"
+
+
+def test_notice_is_unchanged_when_license_collection_is_empty(monkeypatch, tmp_path: Path):
+    manifest = {
+        "name": "Example",
+        "license": "Copyright (c) 2026 Splunk Inc.",
+    }
+    (tmp_path / "example.json").write_text(json.dumps(manifest))
+    (tmp_path / "requirements.txt").write_text("demo-package==1.0.0\n")
+    notice_path = tmp_path / "NOTICE"
+    notice_path.write_text("existing notice\n")
+    monkeypatch.setattr(generate_notice, "get_python_license_info", lambda **_kwargs: iter(()))
+    monkeypatch.setattr(sys, "argv", ["generate_notice.py", str(tmp_path)])
+
+    with pytest.raises(RuntimeError, match="Unable to collect license metadata"):
+        generate_notice.main()
+
+    assert notice_path.read_text() == "existing notice\n"


### PR DESCRIPTION
### Summary

- Collect dependency license metadata before replacing a connector NOTICE file.
- Render into a temporary file and atomically replace NOTICE only after generation succeeds.
- Preserve an existing NOTICE when license collection fails or the hook is interrupted.

This was found while remediating RSA Archer: the hook truncated its lxml attribution before a slow license lookup completed, leaving a zero-byte NOTICE when the process was interrupted.

Tracking: [PAPP-38051](https://splunk.atlassian.net/browse/PAPP-38051).

### Verification

- `pytest local_hooks/tests/test_generate_notice.py` — 14 passed
- `pre-commit run --all-files`

Written by Codex with AI assistance.