### PR TITLE
perf: remove unused jq bootstrap from dependency packaging

### DIFF
--- a/local_hooks/package_app_dependencies.sh
+++ b/local_hooks/package_app_dependencies.sh
@@ -46,13 +46,6 @@ fi
 # Limit that path to local_hooks imports so container pip3.9/pip3.13 use their own interpreter-local pip.
 unset PYTHONPATH
 
-# Remove any existing wheels in wheels/ and app json
-yum install jq -y
-if ! jq --help &>/dev/null; then
-	echo 'Something went wrong installing jq. Could not find it on PATH after installation. Aborting'
-	exit 1
-fi
-
 py39_deps='pip39_dependencies'
 py313_deps='pip313_dependencies'
 SCRIPT="python -m local_hooks.package_app_dependencies"

--- a/local_hooks/tests/test_package_app_dependencies.py
+++ b/local_hooks/tests/test_package_app_dependencies.py
@@ -2,11 +2,19 @@ import json
 import os
 import shutil
 import subprocess
+from pathlib import Path
 
 import pytest
 from uuid import uuid4
 
 PRE_COMMIT_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+
+
+def test_package_wrapper_does_not_install_os_packages():
+    wrapper = Path(PRE_COMMIT_DIR, "package_app_dependencies.sh").read_text()
+
+    assert "yum install" not in wrapper
+    assert "dnf install" not in wrapper
 
 
 @pytest.fixture(


### PR DESCRIPTION
## Summary

- remove the unused `yum install jq` bootstrap from connector dependency packaging
- keep wheel and app-manifest reconciliation in the existing Python packager
- add a regression test preventing runtime OS-package-manager bootstrap from returning

This removes roughly 10-15 minutes of repeated repository metadata downloads from each clean connector packaging pass observed during the ESPM-5228 remediation campaign.

## Validation

- targeted pytest: 1 passed
- non-Docker pre-commit hooks: passed
- `bash -n local_hooks/package_app_dependencies.sh`
- Docker-backed shfmt deferred to GitHub pre-commit because the connector fleet uses a serialized local Docker gate

Tracking: ESPM-5228

Written by Codex.