### PR TITLE
fix: reuse packaged wheels for notice metadata

### DIFF
--- a/local_hooks/generate_notice.py
+++ b/local_hooks/generate_notice.py
@@ -252,9 +252,17 @@ def load_license_info_with_pip(packages: list[str], requirements_path: Path) -> 
         "pip",
         "install",
         "pip-licenses",
-        "-r",
-        str(requirements_path),
     ]
+    wheel_root = requirements_path.parent / "wheels"
+    wheel_directories = (
+        wheel_root / "py3",
+        wheel_root / f"py{sys.version_info.major}{sys.version_info.minor}",
+        wheel_root / "shared",
+    )
+    for wheel_directory in wheel_directories:
+        if wheel_directory.is_dir():
+            install_command.extend(("--find-links", str(wheel_directory)))
+    install_command.extend(("-r", str(requirements_path)))
     install_result = run_command(install_command)
     if install_result.returncode != 0:
         raise RuntimeError(

--- a/local_hooks/tests/test_generate_notice.py
+++ b/local_hooks/tests/test_generate_notice.py
@@ -177,6 +177,53 @@ def test_get_python_license_info_falls_back_to_current_python_pip(monkeypatch, t
     ]
 
 
+def test_pip_fallback_uses_bundled_connector_wheels(monkeypatch, tmp_path: Path):
+    requirements_path = tmp_path / "requirements.txt"
+    requirements_path.write_text("demo-package==1.0.0\n")
+    wheel_root = tmp_path / "wheels"
+    wheel_directories = [
+        wheel_root / "py3",
+        wheel_root / f"py{sys.version_info.major}{sys.version_info.minor}",
+        wheel_root / "shared",
+    ]
+    for wheel_directory in wheel_directories:
+        wheel_directory.mkdir(parents=True, exist_ok=True)
+
+    commands = []
+    monkeypatch.setattr(generate_notice.shutil, "which", lambda _command: None)
+
+    def fake_run(command: list[str]):
+        commands.append(command)
+        if command == [sys.executable, "-m", "pip", "--version"]:
+            return completed(command, "pip 1.0\n")
+        if command[:4] == [sys.executable, "-m", "pip", "install"]:
+            return completed(command)
+        if command[:3] == [sys.executable, "-m", "piplicenses"]:
+            return completed(command, license_rows("demo-package"))
+        raise AssertionError(f"Unexpected command: {command}")
+
+    monkeypatch.setattr(generate_notice, "run_command", fake_run)
+
+    rows = list(generate_notice.get_python_license_info(["demo-package"], requirements_path))
+
+    assert [row.package_name for row in rows] == ["demo-package"]
+    assert commands[1] == [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "pip-licenses",
+        "--find-links",
+        str(wheel_directories[0]),
+        "--find-links",
+        str(wheel_directories[1]),
+        "--find-links",
+        str(wheel_directories[2]),
+        "-r",
+        str(requirements_path),
+    ]
+
+
 def test_get_python_license_info_fails_without_uv_or_pip(monkeypatch, tmp_path: Path):
     requirements_path = tmp_path / "requirements.txt"
     requirements_path.write_text("demo-package==1.0.0\n")


### PR DESCRIPTION
## Why

The NOTICE hook's pip fallback rebuilt connector requirements from package indexes instead of preferring the compatible wheels already packaged by the connector. Kafka and Microsoft SCCM therefore attempted to rebuild legacy Kerberos dependencies under Python 3.13 even though both connectors already ship compatible wheels.

MISP was removed from this change after tracing its packaged setuptools dependency to an obsolete PyMISP/jsonschema chain; that dependency is being corrected in the connector instead.

## Why this belongs in the NOTICE hook

Kafka and Microsoft SCCM require native Kerberos modules at runtime, rather than carrying obsolete build-only dependencies:

- Kafka uses `gssapi`. The current upstream release still publishes no Linux wheel and requires system GSSAPI/Kerberos headers when built from source.
- Microsoft SCCM uses `pykerberos`. Its latest upstream release is source-only.

Both connectors already package compatible Linux wheels for their supported Python runtimes. Adding `--find-links` directives to each connector's `requirements.txt` was tested successfully in clean linux/amd64 Python 3.9 and 3.13 containers, so a connector-local workaround is possible. It would, however, duplicate interpreter-specific packaging knowledge in every connector that ships native wheels.

The NOTICE fallback owns the temporary dependency installation and already receives the connector path. Having it prefer the connector's canonical wheel directories keeps NOTICE metadata aligned with the artifacts actually shipped and fixes the behavior once for native-wheel connectors without changing their runtime dependency declarations.

## Tracking

- PAPP-38222 — Kafka
- PAPP-38246 — Microsoft SCCM
- Parent epic: ESPM-5228

## Changes

- pass connector wheel directories to pip with `--find-links` before installing NOTICE dependencies
- cover the command construction with a focused test

## Verification

- focused NOTICE tests: 18 passed
- full dev-cicd-tools pre-commit suite: passed

Written by Codex.

## Fresh connector confirmation

Codex reran the hosted pre-commit jobs after the shared runner repair. Kafka, Microsoft SCCM, and Microsoft Windows Remote Management all still fail in the same NOTICE fallback while installing their shipped native Kerberos requirements; their compile checks pass. This also blocks PAPP-38250 / https://github.com/splunk-soar-connectors/microsoftwindowsremotemanagement/pull/63.

Written by Codex.