### PR TITLE
fix: allow canonical connector template placeholders

### DIFF
--- a/local_hooks/app_tests/json_tests.py
+++ b/local_hooks/app_tests/json_tests.py
@@ -23,6 +23,11 @@ from packaging.version import Version
 from pathlib import Path
 
 SKIP_SDK_APP = {"success": True, "message": "TEST SKIPPED - SDK app detected"}
+CONNECTOR_TEMPLATE_IDENTITY = {
+    "appid": "ffffffff-ffff-4fff-afff-ffffffffffff",
+    "name": "Example App Name",
+    "package_name": "phantom_template",
+}
 
 
 class JSONTests(TestSuite):
@@ -31,6 +36,13 @@ class JSONTests(TestSuite):
         self._app_json = self._parser.app_json
 
         self._app_is_certified = self._parser.app_json["publisher"] == "Splunk"
+
+    def _is_connector_template_placeholder(self) -> bool:
+        """Return whether this is the canonical connector-template placeholder app."""
+        return self._app_code_dir.name == "connector-template" and all(
+            self._app_json.get(field) == value
+            for field, value in CONNECTOR_TEMPLATE_IDENTITY.items()
+        )
 
     @staticmethod
     def format_as_index(indices: list[Any], container: str = "schema") -> str:
@@ -250,6 +262,9 @@ class JSONTests(TestSuite):
         """
         App Name and GUID must be unique
         """
+        if self._is_connector_template_placeholder():
+            return create_test_result_response(success=True, message=TEST_PASS_MESSAGE)
+
         app_name = self._app_json["name"]
         app_guid = self._app_json["appid"]
 
@@ -285,6 +300,9 @@ class JSONTests(TestSuite):
         """
         Package name is unique
         """
+        if self._is_connector_template_placeholder():
+            return create_test_result_response(success=True, message=TEST_PASS_MESSAGE)
+
         package_name = self._app_json["package_name"]
         app_guid = self._app_json["appid"]
 

--- a/local_hooks/tests/test_static_tests.py
+++ b/local_hooks/tests/test_static_tests.py
@@ -127,3 +127,33 @@ def test_pip313_dependencies_still_requires_generated_key(tmp_path: Path):
     assert result["message"] == (
         "App json must contain 'pip313_dependencies' key when requirements.txt exists"
     )
+
+
+def test_connector_template_placeholder_skips_registry_checks(tmp_path: Path):
+    suite = JSONTests.__new__(JSONTests)
+    suite._app_code_dir = tmp_path / "connector-template"
+    suite._app_json = {
+        "appid": "ffffffff-ffff-4fff-afff-ffffffffffff",
+        "name": "Example App Name",
+        "package_name": "phantom_template",
+    }
+
+    with patch("local_hooks.app_tests.json_tests.requests.get") as mock_get:
+        name_result = suite.check_valid_app_name_and_guid()
+        package_result = suite.check_app_package_name()
+
+    assert name_result["success"] is True
+    assert package_result["success"] is True
+    mock_get.assert_not_called()
+
+
+def test_connector_template_exemption_requires_exact_placeholder(tmp_path: Path):
+    suite = JSONTests.__new__(JSONTests)
+    suite._app_code_dir = tmp_path / "connector-template"
+    suite._app_json = {
+        "appid": "ffffffff-ffff-4fff-afff-ffffffffffff",
+        "name": "A Real App",
+        "package_name": "phantom_template",
+    }
+
+    assert suite._is_connector_template_placeholder() is False


### PR DESCRIPTION
## Summary

- exempt the canonical `connector-template` placeholder identity from production app-name/GUID/package registry checks
- require the exact template directory, reserved GUID, name, and package so real connectors remain covered
- add regression tests for both the exemption and an altered identity

This unblocks [connector-template PR #10](https://github.com/splunk-soar-connectors/connector-template/pull/10), which remediates [PAPP-38137](https://splunk.atlassian.net/browse/PAPP-38137) / [PSAAS-30958](https://splunk.atlassian.net/browse/PSAAS-30958).

## Validation

- `pre-commit run --all-files`
- focused static-test suite: 6 passed
- full suite: 28 passed; six unrelated existing Docker packaging cases fail because the local host is arm64 and the test image is amd64

PR authored by Codex.