### PR TITLE
fix: respect declared dependency runtimes

### DIFF
--- a/local_hooks/package_app_dependencies.py
+++ b/local_hooks/package_app_dependencies.py
@@ -135,6 +135,27 @@ def _load_app_json(app_dir):
         return AppJson(json_files[0], json.load(f))
 
 
+def _should_package_pip_dependency_key(app_dir, pip_dependencies_key):
+    """Return whether a runtime-specific dependency section should be packaged.
+
+    Generic Python 3 apps retain the historical behavior of building both
+    supported runtime sections, even when one is not yet present in the
+    manifest. An app that explicitly declares a single supported runtime only
+    builds the corresponding dependency section.
+    """
+
+    app_json = _load_app_json(app_dir).content
+    if pip_dependencies_key in app_json:
+        return True
+
+    python_version = str(app_json.get("python_version", "3"))
+    runtime_dependency_keys = {
+        "3.9": PipDependency.PYTHON3_9.value,
+        "3.13": PipDependency.PYTHON3_13.value,
+    }
+    return runtime_dependency_keys.get(python_version, pip_dependencies_key) == pip_dependencies_key
+
+
 def _repair_wheels(wheels_to_check, all_wheels, wheels_dir):
     """
     Uses auditwheel to 1) check for platform wheels depending on external binary dependencies

--- a/local_hooks/package_app_dependencies.sh
+++ b/local_hooks/package_app_dependencies.sh
@@ -59,10 +59,32 @@ run_packager() {
 	fi
 }
 
-env -u PYTHONPATH pip3.9 install pip-tools
-run_packager . "$(which pip3.9)" "$py39_deps" --repair-wheels
+has_pip_dependency_key() {
+	local dependency_key="$1"
+	local check_dependency_key
+	check_dependency_key='from local_hooks.package_app_dependencies import _should_package_pip_dependency_key; import sys; sys.exit(not _should_package_pip_dependency_key(".", sys.argv[1]))'
 
-env -u PYTHONPATH pip3.13 install pip-tools
-run_packager . "$(which pip3.13)" "$py313_deps" --repair-wheels
+	if [[ -n "${HOOKS_PYTHONPATH:-}" ]]; then
+		PYTHONPATH="$HOOKS_PYTHONPATH" python -c "$check_dependency_key" "$dependency_key"
+	else
+		python -c "$check_dependency_key" "$dependency_key"
+	fi
+}
+
+package_dependencies() {
+	local dependency_key="$1"
+	local pip_path="$2"
+
+	if ! has_pip_dependency_key "$dependency_key"; then
+		echo "Skipping $dependency_key because it is not declared in the app manifest"
+		return
+	fi
+
+	env -u PYTHONPATH "$pip_path" install pip-tools
+	run_packager . "$pip_path" "$dependency_key" --repair-wheels
+}
+
+package_dependencies "$py39_deps" "$(which pip3.9)"
+package_dependencies "$py313_deps" "$(which pip3.13)"
 
 exit $?

--- a/local_hooks/tests/test_package_app_dependencies.py
+++ b/local_hooks/tests/test_package_app_dependencies.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import pytest
 from uuid import uuid4
 
+from local_hooks.package_app_dependencies import _should_package_pip_dependency_key
+
 PRE_COMMIT_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
 
@@ -15,6 +17,21 @@ def test_package_wrapper_does_not_install_os_packages():
 
     assert "yum install" not in wrapper
     assert "dnf install" not in wrapper
+
+
+def test_package_wrapper_respects_explicit_python_runtime(tmp_path):
+    wrapper = Path(PRE_COMMIT_DIR, "package_app_dependencies.sh").read_text()
+    legacy_app_dir = os.path.join(PRE_COMMIT_DIR, "tests/data/py3-app")
+    python313_app_dir = tmp_path / "python313-app"
+    python313_app_dir.mkdir()
+    (python313_app_dir / "app.json").write_text('{"python_version": "3.13"}\n')
+
+    assert _should_package_pip_dependency_key(legacy_app_dir, "pip39_dependencies")
+    assert _should_package_pip_dependency_key(legacy_app_dir, "pip313_dependencies")
+    assert not _should_package_pip_dependency_key(python313_app_dir, "pip39_dependencies")
+    assert _should_package_pip_dependency_key(python313_app_dir, "pip313_dependencies")
+    assert 'package_dependencies "$py39_deps"' in wrapper
+    assert 'package_dependencies "$py313_deps"' in wrapper
 
 
 @pytest.fixture(


### PR DESCRIPTION
Written by Codex.

## What changed

The dependency-packaging hook now builds only the runtime-specific dependency sections that an app manifest declares.

## Why

The hook unconditionally invoked Python 3.9 and Python 3.13. A Python 3.13-only connector using a dependency that requires Python >=3.10 therefore failed under an undeclared Python 3.9 build before its actual target runtime was evaluated.

## Impact

Existing dual-runtime connectors still package both declared sections. Python 3.13-only connectors no longer require an obsolete `pip39_dependencies` section.

## Validation

- Targeted dependency-runtime tests: passed on Python 3.13
- Ruff check and formatting: passed on Python 3.13
- Full pre-commit bootstrap is currently blocked before hooks execute by a 401 fetching `setuptools` from the configured internal package index.